### PR TITLE
Add BUFFFOOD Crunchy Spider Skewer

### DIFF
--- a/WizardsWardrobeConst.lua
+++ b/WizardsWardrobeConst.lua
@@ -121,6 +121,7 @@ WW.BUFFFOOD = {
 	[68236] = 61260,    -- Firsthold Fruit and Cheese Plate
 	[68237] = 61260,    -- Thrice-Baked Gorapple Pie
 	[68238] = 61260,    -- Tomato Garlic Chutney
+	[87691] = 84709,	-- Crunchy Spider Skewer
 	
 	[112425] = 86673, 	-- Lava Foot Soup-and-Saltrice
 	[120763] = 89957,	-- Dubious Camoran Throne


### PR DESCRIPTION
#### Features:
This adds the buff food "Crunchy Spider Skewer" as a valid buff food.

#### Testing:
Tested on ESO Live client by modifying lua locally:
![image](https://user-images.githubusercontent.com/102873126/161393997-3b6d1853-f093-4a1f-b956-fbcde8f89eed.png)
