### PR TITLE
Add option to print log messages to alert

### DIFF
--- a/src/WizardsWardrobeMenu.lua
+++ b/src/WizardsWardrobeMenu.lua
@@ -48,7 +48,7 @@ function WWM.InitSV()
 			surfingWeapons = false,
 		},
 		changelogs = {},
-		printMessages = true,
+		printMessages = 'chat',
 		overwriteWarning = true,
 		inventoryMarker = true,
 		unequipEmpty = false,
@@ -58,6 +58,13 @@ function WWM.InitSV()
 		eatBuffFood = false,
 		initialized = false,
 	})
+
+	-- migrate printMessage settings
+	if WW.settings.printMessages == true then
+		WW.settings.printMessages = 'chat'
+	elseif WW.settings.printMessages == false then
+		WW.settings.printMessages = 'off'
+	end
 	
 	-- dont look at this
 	WW.settings.autoEquipSetups = WW.storage.autoEquipSetups
@@ -84,10 +91,13 @@ function WWM.InitAM()
 			name = GetString(WW_MENU_GENERAL),
 		},
 		{
-			type = "checkbox",
+			type = "dropdown",
 			name = GetString(WW_MENU_PRINTCHAT),
+			choices = { GetString(WW_MENU_PRINTCHAT_OFF), GetString(WW_MENU_PRINTCHAT_CHAT), GetString(WW_MENU_PRINTCHAT_ALERT) },
+			choicesValues = { 'off', 'chat', 'alert' },
 			getFunc = function() return WW.settings.printMessages end,
 			setFunc = function(value) WW.settings.printMessages = value end,
+			tooltip = GetString(WW_MENU_PRINTCHAT_TT),
 		},
 		{
 			type = "checkbox",
@@ -291,3 +301,4 @@ function WWM.InitAM()
 	WWM.panel = LibAddonMenu2:RegisterAddonPanel("WizardsWardrobeMenu", panelData)
 	LibAddonMenu2:RegisterOptionControls("WizardsWardrobeMenu", optionData)
 end
+

--- a/src/WizardsWardrobeUtils.lua
+++ b/src/WizardsWardrobeUtils.lua
@@ -100,14 +100,19 @@ function WW.IsWipe()
 end
 
 function WW.Log(logMessage, logType, formatColor, ...)
-	if WW.settings.printMessages then
+	if WW.settings.printMessages == 'chat' or WW.settings.printMessages == 'alert' then
 		if not logType then logType = WW.LOGTYPES.NORMAL end
 		if not formatColor then formatColor = "FFFFFF" end
 		logMessage = string.format(logMessage, ...)
 		logMessage = string.gsub(logMessage, "%[", "|c" .. formatColor .. "[")
 		logMessage = string.gsub(logMessage, "%]", "]|c" .. logType)
 		logMessage = string.format("|c18bed8[|c65d3b0W|cb2e789W|cfffc61]|r|c%s %s|r", logType, logMessage)
-		CHAT_ROUTER:AddSystemMessage(logMessage)
+
+		if (WW.settings.printMessages == 'alert') then
+			ZO_Alert(UI_ALERT_CATEGORY_ALERT, nil, logMessage)
+		else
+			CHAT_ROUTER:AddSystemMessage(logMessage)
+		end
 	end
 end
 

--- a/src/lang/de.lua
+++ b/src/lang/de.lua
@@ -53,7 +53,11 @@ local language = {
 	
 	-- ADDON MENU
 	WW_MENU_GENERAL = "Allgemein",
-	WW_MENU_PRINTCHAT = "Nachrichten im Chat",
+	WW_MENU_PRINTCHAT = "Meldungen",
+	WW_MENU_PRINTCHAT_TT = "Gibt Meldungen über geladene Setups im Chat oder Benachrichtigungsfenster aus.",
+	WW_MENU_PRINTCHAT_OFF = "Deaktiviert",
+	WW_MENU_PRINTCHAT_CHAT = "Chat",
+	WW_MENU_PRINTCHAT_ALERT = "Benachrichtigung",	
 	WW_MENU_OVERWRITEWARNING = "Warnung beim Überschreiben",
 	WW_MENU_OVERWRITEWARNING_TT = "Zeigt eine Warnung wenn ein bereits gespeichertes Setup überschrieben wird.",
 	WW_MENU_INVENTORYMARKER = "Inventarmarker",

--- a/src/lang/en.lua
+++ b/src/lang/en.lua
@@ -53,7 +53,11 @@ local language = {
 	
 	-- ADDON MENU
 	WW_MENU_GENERAL = "General",
-	WW_MENU_PRINTCHAT = "Print messages into chat",
+	WW_MENU_PRINTCHAT = "Print messages",
+	WW_MENU_PRINTCHAT_TT = "Prints messages about loaded setups into the chat or the alert notifications",
+	WW_MENU_PRINTCHAT_OFF = "Disabled",
+	WW_MENU_PRINTCHAT_CHAT = "Chat",
+	WW_MENU_PRINTCHAT_ALERT = "Alert",
 	WW_MENU_OVERWRITEWARNING = "Show warning on overwrite",
 	WW_MENU_OVERWRITEWARNING_TT = "Shows a warning if an already saved setup is overwritten.",
 	WW_MENU_INVENTORYMARKER = "Inventory marker",


### PR DESCRIPTION
I wanted to be notified about the equipment changes but I didn't want my chat to get spammed. So I added the option to print the log to ingame alerts instead.