### PR TITLE
Remove April Fool's Joke

### DIFF
--- a/src/WizardsWardrobeGui.lua
+++ b/src/WizardsWardrobeGui.lua
@@ -216,10 +216,6 @@ function WWG.SetSceneManagement()
 			}
 		end
 	end
-	
-	if os.date("%d%m") == "0104" then
-		WizardsWardrobeWindow:SetTransformRotationZ(math.rad(180))
-	end
 end
 
 function WWG.SetDialogManagement()


### PR DESCRIPTION
This 'joke' heavily impairs user experience as well as makes the add-on unfriendly to those with eye-sight issues, which presents an issue as it lasts for the entire day of April 1st. There is no way to toggle this off other than to manually edit the source, which many people wouldn't know how or where to do this in the first place; as such, this should just be removed. If this change is rejected, please at least add the ability to toggle it on/off - with the preference of it being only if opted in to.