### PR TITLE
Reload current setup option

### DIFF
--- a/src/Bindings.xml
+++ b/src/Bindings.xml
@@ -69,9 +69,12 @@
 			</Action>
 			<Action name="WW_HOTKEY_UNDRESS">
 				<Down>WizardsWardrobe.Undress()</Down>
-      </Action>
+			</Action>
 			<Action name="WW_HOTKEY_SETUP_PREVIOUS">
 				<Down>WizardsWardrobe.LoadSetupAdjacent(-1)</Down>
+			</Action>
+			<Action name="WW_HOTKEY_SETUP_CURRENT">
+				<Down>WizardsWardrobe.LoadSetupAdjacent(0)</Down>
 			</Action>
 			<Action name="WW_HOTKEY_SETUP_NEXT">
 				<Down>WizardsWardrobe.LoadSetupAdjacent(1)</Down>

--- a/src/lang/en.lua
+++ b/src/lang/en.lua
@@ -296,6 +296,7 @@ local language = {
 
 	SI_BINDING_NAME_WW_HOTKEY_UNDRESS = "Undress",
 	SI_BINDING_NAME_WW_HOTKEY_SETUP_PREVIOUS = "Equip previous setup",
+	SI_BINDING_NAME_WW_HOTKEY_SETUP_CURRENT = "Reload current setup",
 	SI_BINDING_NAME_WW_HOTKEY_SETUP_NEXT = "Equip next setup"
 }
 

--- a/src/lang/fr.lua
+++ b/src/lang/fr.lua
@@ -275,6 +275,11 @@ local language = {
 	SI_BINDING_NAME_WW_HOTKEY_PREBUFF_3 = "Prebuff 3",
 	SI_BINDING_NAME_WW_HOTKEY_PREBUFF_4 = "Prebuff 4",
 	SI_BINDING_NAME_WW_HOTKEY_PREBUFF_5 = "Prebuff 5",
+
+	SI_BINDING_NAME_WW_HOTKEY_UNDRESS = "Déshabiller",
+	SI_BINDING_NAME_WW_HOTKEY_SETUP_PREVIOUS = "Equiper le profil précédent",
+	SI_BINDING_NAME_WW_HOTKEY_SETUP_CURRENT = "Recharger le profil actuel",
+	SI_BINDING_NAME_WW_HOTKEY_SETUP_NEXT = "Equiper le prochain profil"
 }
 
 for key, value in pairs(language) do


### PR DESCRIPTION
The previous/next setup option is really nice but sometimes some gear may fail to swap.
This PR adds the option to reload the current setup to address this issue.