### PR TITLE
1.16.0

### DIFF
--- a/src/Bindings.xml
+++ b/src/Bindings.xml
@@ -79,6 +79,9 @@
 			<Action name="WW_HOTKEY_SETUP_NEXT">
 				<Down>WizardsWardrobe.LoadSetupAdjacent(1)</Down>
 			</Action>
+			<Action name="WW_HOTKEY_SETUP_FIX">
+				<Down>WizardsWardrobe.validation.WorkAroundOne()</Down>
+			</Action>
 		</Category>
 	</Layer>
 </Bindings>

--- a/src/WizardsWardrobe.txt
+++ b/src/WizardsWardrobe.txt
@@ -1,9 +1,9 @@
 ## Title: Wizard's Wardrobe
 ## Author: ownedbynico, |c268074JN_Slevin|r, |c00a313Ghostbane|r
-## Version: 1.14.0
+## Version: 1.16.0
 ## Description: Throw all your setups into the wardrobe and let the wizard equip them exactly when you need it.
-## APIVersion: 101039
-## DependsOn: LibAddonMenu-2.0 LibChatMessage>=105
+## APIVersion: 101040
+## DependsOn: LibAddonMenu-2.0 LibChatMessage>=105 LibDebugLogger LibAsync
 ## SavedVariables: WizardsWardrobeSV
 
 ## This Add-on is not created by, affiliated with or sponsored by ZeniMax Media Inc. or its affiliates.
@@ -25,6 +25,7 @@ WizardsWardrobeSetup.lua
 WizardsWardrobeConst.lua
 WizardsWardrobeUtils.lua
 WizardsWardrobeQueue.lua
+WizardsWardrobeSetupValidation.lua
 
 modules/WizardsWardrobeConditions.lua
 modules/WizardsWardrobeTransfer.lua
@@ -42,6 +43,7 @@ WizardsWardrobeGui.lua
 WizardsWardrobeMenu.lua
 WizardsWardrobe.lua
 
+
 zones/GEN.lua
 zones/SUB.lua
 zones/PVP.lua
@@ -58,4 +60,3 @@ zones/RG.lua
 zones/DSR.lua
 zones/SE.lua
 zones/BRP.lua
-zones/EA.lua

--- a/src/WizardsWardrobeGui.lua
+++ b/src/WizardsWardrobeGui.lua
@@ -27,11 +27,11 @@ local SETUP_BOX_HEIGHT = 128
 function WWG.Init()
 	WWG.name = WW.name .. "Gui"
 	WWG.setupTable = {}
-	
+
 	WWG.HandleFirstStart()
 	WWG.SetSceneManagement()
 	WWG.SetDialogManagement()
-	
+
 	WWG.SetupPanel()
 	WWG.SetupWindow()
 	WWG.SetupPageMenu()
@@ -39,177 +39,177 @@ function WWG.Init()
 	WWG.SetupBottomMenu()
 	WWG.CreateSetupPool()
 	WWG.SetupTopMenu()
-	
+
 	WWG.SetupModifyDialog()
 	WWG.SetupArrangeDialog()
-	
+
 	WWG.RegisterEvents()
-	
-	zo_callLater(function() WWG.OnWindowResize("stop") end, 250)
+
+	zo_callLater( function() WWG.OnWindowResize( "stop" ) end, 250 )
 end
 
 function WWG.RegisterEvents()
-	EVENT_MANAGER:RegisterForEvent(WWG.name, EVENT_PLAYER_DEAD, function() WizardsWardrobePanel.fragment:Refresh() end)
-	EVENT_MANAGER:RegisterForEvent(WWG.name, EVENT_PLAYER_ALIVE, function() WizardsWardrobePanel.fragment:Refresh() end)
+	EVENT_MANAGER:RegisterForEvent( WWG.name, EVENT_PLAYER_DEAD, function() WizardsWardrobePanel.fragment:Refresh() end )
+	EVENT_MANAGER:RegisterForEvent( WWG.name, EVENT_PLAYER_ALIVE, function() WizardsWardrobePanel.fragment:Refresh() end )
 end
 
 function WWG.HandleFirstStart()
 	if not WW.settings.changelogs then WW.settings.changelogs = {} end
-	
+
 	if not WW.settings.initialized then
-		local function HandleClickEvent(rawLink, mouseButton, linkText, linkStyle, linkType, dataString)
+		local function HandleClickEvent( rawLink, mouseButton, linkText, linkStyle, linkType, dataString )
 			if linkType ~= WW.LINK_TYPES.URL then return end
 			if mouseButton == MOUSE_BUTTON_INDEX_LEFT then
 				if dataString == "esoui" then
-					RequestOpenUnsafeURL("https://www.esoui.com/downloads/info3170-WizardsWardrobe.html")
+					RequestOpenUnsafeURL( "https://www.esoui.com/downloads/info3170-WizardsWardrobe.html" )
 				end
 			end
 			return true
 		end
-		LibChatMessage:RegisterCustomChatLink(WW.LINK_TYPES.URL, function(linkStyle, linkType, data, displayText)
-			return ZO_LinkHandler_CreateLinkWithoutBrackets(displayText, nil, WW.LINK_TYPES.URL, data)
-		end)
-		LINK_HANDLER:RegisterCallback(LINK_HANDLER.LINK_MOUSE_UP_EVENT, HandleClickEvent)
-		LINK_HANDLER:RegisterCallback(LINK_HANDLER.LINK_CLICKED_EVENT, HandleClickEvent)
-		zo_callLater(function()
-				local urlLink = ZO_LinkHandler_CreateLink("esoui.com", nil, WW.LINK_TYPES.URL, "esoui")
-				local pattern = string.format("|c18bed8[|c65d3b0W|cb2e789W|cfffc61]|r |cFFFFFF%s|r", GetString(WW_MSG_FIRSTSTART))
-				local output = string.format(pattern, "|r" .. urlLink .. "|cFFFFFF")
-				CHAT_ROUTER:AddSystemMessage(output)
-				WW.settings.initialized = true
-		end, 500)
-		
+		LibChatMessage:RegisterCustomChatLink( WW.LINK_TYPES.URL, function( linkStyle, linkType, data, displayText )
+			return ZO_LinkHandler_CreateLinkWithoutBrackets( displayText, nil, WW.LINK_TYPES.URL, data )
+		end )
+		LINK_HANDLER:RegisterCallback( LINK_HANDLER.LINK_MOUSE_UP_EVENT, HandleClickEvent )
+		LINK_HANDLER:RegisterCallback( LINK_HANDLER.LINK_CLICKED_EVENT, HandleClickEvent )
+		zo_callLater( function()
+						  local urlLink = ZO_LinkHandler_CreateLink( "esoui.com", nil, WW.LINK_TYPES.URL, "esoui" )
+						  local pattern = string.format( "|c18bed8[|c65d3b0W|cb2e789W|cfffc61]|r |cFFFFFF%s|r",
+							  GetString( WW_MSG_FIRSTSTART ) )
+						  local output = string.format( pattern, "|r" .. urlLink .. "|cFFFFFF" )
+						  CHAT_ROUTER:AddSystemMessage( output )
+						  WW.settings.initialized = true
+					  end, 500 )
+
 		-- dont show changelogs if first time
-		WW.settings.changelogs["v1.8.0"] = true
+		WW.settings.changelogs[ "v1.8.0" ] = true
 		return
 	end
-	
-	if not WW.settings.changelogs["v1.8.0"] then
-		EVENT_MANAGER:RegisterForUpdate(WWG.name .. "UpdateWarning", 1000, function()
-			if not WW.settings.changelogs["v1.8.0"]
+
+	if not WW.settings.changelogs[ "v1.8.0" ] then
+		EVENT_MANAGER:RegisterForUpdate( WWG.name .. "UpdateWarning", 1000, function()
+			if not WW.settings.changelogs[ "v1.8.0" ]
 				and not ZO_Dialogs_IsShowingDialog() then
-				
-				WWG.ShowConfirmationDialog(WWG.name .. "UpdateWarning", GetString(WW_CHANGELOG), function()
-					EVENT_MANAGER:UnregisterForUpdate(WWG.name .. "UpdateWarning")
-					WW.settings.changelogs["v1.8.0"] = true
-					RequestOpenUnsafeURL("https://www.esoui.com/downloads/info3170-WizardsWardrobe.html")
-				end)
+				WWG.ShowConfirmationDialog( WWG.name .. "UpdateWarning", GetString( WW_CHANGELOG ), function()
+					EVENT_MANAGER:UnregisterForUpdate( WWG.name .. "UpdateWarning" )
+					WW.settings.changelogs[ "v1.8.0" ] = true
+					RequestOpenUnsafeURL( "https://www.esoui.com/downloads/info3170-WizardsWardrobe.html" )
+				end )
 			end
-		end)
+		end )
 	end
 end
 
-function WWG.SetSceneManagement()	
-	local onSceneChange = function(scene, oldState, newState)	
+function WWG.SetSceneManagement()
+	local onSceneChange = function( scene, oldState, newState )
 		local sceneName = scene:GetName()
-		
+
 		if sceneName == "gameMenuInGame" then return end
-		
+
 		if newState == SCENE_SHOWING then
-			local savedScene = WW.settings.window[sceneName]
+			local savedScene = WW.settings.window[ sceneName ]
 			if savedScene then
 				if not savedScene.hidden then
 					WizardsWardrobeWindow:ClearAnchors()
-					WizardsWardrobeWindow:SetAnchor(TOPLEFT, GUI_ROOT, TOPLEFT, savedScene.left, savedScene.top)
-					WizardsWardrobeWindow:SetHidden(false)
+					WizardsWardrobeWindow:SetAnchor( TOPLEFT, GUI_ROOT, TOPLEFT, savedScene.left, savedScene.top )
+					WizardsWardrobeWindow:SetHidden( false )
 				end
 			end
 		end
-		
+
 		-- looks better when window hides faster
 		if newState == SCENE_HIDING then
-			local savedScene = WW.settings.window[sceneName]
+			local savedScene = WW.settings.window[ sceneName ]
 			if savedScene then
-				WizardsWardrobeWindow:SetHidden(true)
+				WizardsWardrobeWindow:SetHidden( true )
 			end
 			if sceneName == "hud" or sceneName == "hudui" then
-				if not WW.settings.window[sceneName] then
-					WW.settings.window[sceneName] = {
+				if not WW.settings.window[ sceneName ] then
+					WW.settings.window[ sceneName ] = {
 						top = WizardsWardrobeWindow:GetTop(),
 						left = WizardsWardrobeWindow:GetLeft(),
 						hidden = true,
 					}
 				end
-				WW.settings.window[sceneName].hidden = true
+				WW.settings.window[ sceneName ].hidden = true
 			end
 		end
 	end
-	SCENE_MANAGER:RegisterCallback("SceneStateChanged", onSceneChange)
-	
+	SCENE_MANAGER:RegisterCallback( "SceneStateChanged", onSceneChange )
+
 	-- quickslot tab will internally act like a independent scene
-	KEYBOARD_QUICKSLOT_FRAGMENT:RegisterCallback("StateChange", function(oldState, newState)
+	KEYBOARD_QUICKSLOT_FRAGMENT:RegisterCallback( "StateChange", function( oldState, newState )
 		local quickslot = {
-			GetName = function(GetName)
+			GetName = function( GetName )
 				return "inventoryQuickslot"
 			end
 		}
-		local inventoryScene = SCENE_MANAGER:GetScene("inventory")
+		local inventoryScene = SCENE_MANAGER:GetScene( "inventory" )
 		if newState == SCENE_SHOWING then
-			onSceneChange(inventoryScene, SCENE_SHOWN, SCENE_HIDING)
-			onSceneChange(quickslot, SCENE_HIDDEN, SCENE_SHOWING)
+			onSceneChange( inventoryScene, SCENE_SHOWN, SCENE_HIDING )
+			onSceneChange( quickslot, SCENE_HIDDEN, SCENE_SHOWING )
 		elseif newState == SCENE_HIDING then
 			if inventoryScene:IsShowing() then
-				onSceneChange(quickslot, SCENE_SHOWN, SCENE_HIDING)
-				onSceneChange(inventoryScene, SCENE_HIDDEN, SCENE_SHOWING)
+				onSceneChange( quickslot, SCENE_SHOWN, SCENE_HIDING )
+				onSceneChange( inventoryScene, SCENE_HIDDEN, SCENE_SHOWING )
 			else
-				onSceneChange(quickslot, SCENE_SHOWN, SCENE_HIDING)
+				onSceneChange( quickslot, SCENE_SHOWN, SCENE_HIDING )
 			end
 		end
-	end)
-	
-	CALLBACK_MANAGER:RegisterCallback("LAM-PanelControlsCreated", function(panel)
+	end )
+
+	CALLBACK_MANAGER:RegisterCallback( "LAM-PanelControlsCreated", function( panel )
 		if panel:GetName() ~= "WizardsWardrobeMenu" then return end
-		local icon = WINDOW_MANAGER:CreateControl("WizardsWardrobeMenuIcon", panel, CT_TEXTURE)
-		icon:SetTexture("/WizardsWardrobe/assets/icon64.dds")
-		icon:SetDimensions(64, 64)
-		icon:SetAnchor(TOPRIGHT, panel, TOPRIGHT, -45, -25)
-    end)
-	CALLBACK_MANAGER:RegisterCallback("LAM-PanelOpened", function(panel)
+		local icon = WINDOW_MANAGER:CreateControl( "WizardsWardrobeMenuIcon", panel, CT_TEXTURE )
+		icon:SetTexture( "/WizardsWardrobe/assets/icon64.dds" )
+		icon:SetDimensions( 64, 64 )
+		icon:SetAnchor( TOPRIGHT, panel, TOPRIGHT, -45, -25 )
+	end )
+	CALLBACK_MANAGER:RegisterCallback( "LAM-PanelOpened", function( panel )
 		if panel:GetName() ~= "WizardsWardrobeMenu" then return end
 		WizardsWardrobeWindow:ClearAnchors()
-		WizardsWardrobeWindow:SetAnchor(CENTER, GUI_ROOT, RIGHT, -(WizardsWardrobeWindow:GetWidth() / 2 + 50), 0)
-		WizardsWardrobeWindow:SetHidden(false)
-		PlaySound(SOUNDS.DEFAULT_WINDOW_OPEN)
-    end)
-	CALLBACK_MANAGER:RegisterCallback("LAM-PanelClosed", function(panel)
+		WizardsWardrobeWindow:SetAnchor( CENTER, GUI_ROOT, RIGHT, -(WizardsWardrobeWindow:GetWidth() / 2 + 50), 0 )
+		WizardsWardrobeWindow:SetHidden( false )
+		PlaySound( SOUNDS.DEFAULT_WINDOW_OPEN )
+	end )
+	CALLBACK_MANAGER:RegisterCallback( "LAM-PanelClosed", function( panel )
 		if panel:GetName() ~= "WizardsWardrobeMenu" then return end
-		WizardsWardrobeWindow:SetHidden(true)
-    end)
-	
-	SLASH_COMMANDS["/wizard"] = function()
+		WizardsWardrobeWindow:SetHidden( true )
+	end )
+
+	SLASH_COMMANDS[ "/wizard" ] = function()
 		local scene = SCENE_MANAGER:GetCurrentScene()
 		local sceneName = scene:GetName()
 		if sceneName == "gameMenuInGame" then
-			WizardsWardrobeWindow:SetHidden(not WizardsWardrobeWindow:IsHidden())
+			WizardsWardrobeWindow:SetHidden( not WizardsWardrobeWindow:IsHidden() )
 			return
 		end
 		if sceneName == "inventory" and KEYBOARD_QUICKSLOT_FRAGMENT:IsShowing() then
 			sceneName = "inventoryQuickslot"
 		end
-		local savedScene = WW.settings.window[sceneName]
+		local savedScene = WW.settings.window[ sceneName ]
 		if savedScene then
 			if savedScene.hidden then
 				-- open
 				WizardsWardrobeWindow:ClearAnchors()
-				WizardsWardrobeWindow:SetAnchor(TOPLEFT, GUI_ROOT, TOPLEFT, savedScene.left, savedScene.top)
-				WizardsWardrobeWindow:SetHidden(false)
-				PlaySound(SOUNDS.DEFAULT_WINDOW_OPEN)
-				SCENE_MANAGER:SetInUIMode(true, false)
-				WW.settings.window[sceneName].hidden = false
+				WizardsWardrobeWindow:SetAnchor( TOPLEFT, GUI_ROOT, TOPLEFT, savedScene.left, savedScene.top )
+				WizardsWardrobeWindow:SetHidden( false )
+				PlaySound( SOUNDS.DEFAULT_WINDOW_OPEN )
+				SCENE_MANAGER:SetInUIMode( true, false )
+				WW.settings.window[ sceneName ].hidden = false
 			else
 				-- close
-				WizardsWardrobeWindow:SetHidden(true)
-				PlaySound(SOUNDS.DEFAULT_WINDOW_CLOSE)
-				WW.settings.window[sceneName].hidden = true
+				WizardsWardrobeWindow:SetHidden( true )
+				PlaySound( SOUNDS.DEFAULT_WINDOW_CLOSE )
+				WW.settings.window[ sceneName ].hidden = true
 			end
 		else
 			-- open but new
 			WizardsWardrobeWindow:ClearAnchors()
-			WizardsWardrobeWindow:SetAnchor(CENTER, GUI_ROOT, CENTER, 0, 0)
-			WizardsWardrobeWindow:SetHidden(false)
-			PlaySound(SOUNDS.DEFAULT_WINDOW_OPEN)
-			SCENE_MANAGER:SetInUIMode(true, false)
-			WW.settings.window[sceneName] = {
+			WizardsWardrobeWindow:SetAnchor( CENTER, GUI_ROOT, CENTER, 0, 0 )
+			WizardsWardrobeWindow:SetHidden( false )
+			PlaySound( SOUNDS.DEFAULT_WINDOW_OPEN )
+			SCENE_MANAGER:SetInUIMode( true, false )
+			WW.settings.window[ sceneName ] = {
 				top = WizardsWardrobeWindow:GetTop(),
 				left = WizardsWardrobeWindow:GetLeft(),
 				hidden = false,
@@ -220,12 +220,12 @@ end
 
 function WWG.SetDialogManagement()
 	WWG.dialogList = {}
-	SCENE_MANAGER:RegisterCallback("SceneStateChanged", function(scene, oldState, newState)
+	SCENE_MANAGER:RegisterCallback( "SceneStateChanged", function( scene, oldState, newState )
 		if newState ~= SCENE_HIDING then return end
-		for _, dialog in ipairs(WWG.dialogList) do
-			dialog:SetHidden(true)
+		for _, dialog in ipairs( WWG.dialogList ) do
+			dialog:SetHidden( true )
 		end
-	end)
+	end )
 end
 
 function WWG.ResetUI()
@@ -237,7 +237,7 @@ function WWG.ResetUI()
 		setup = true,
 	}
 	WizardsWardrobePanel:ClearAnchors()
-	WizardsWardrobePanel:SetAnchor(TOPLEFT, GUI_ROOT, TOPLEFT, PANEL_DEFAULT_LEFT, PANEL_DEFAULT_TOP)
+	WizardsWardrobePanel:SetAnchor( TOPLEFT, GUI_ROOT, TOPLEFT, PANEL_DEFAULT_LEFT, PANEL_DEFAULT_TOP )
 	WW.settings.window = {
 		wizard = {
 			width = WINDOW_WIDTH,
@@ -246,56 +246,55 @@ function WWG.ResetUI()
 			locked = false,
 		},
 	}
-	WizardsWardrobeWindow:SetWidth(WINDOW_WIDTH)
-	WizardsWardrobeWindow:SetHeight(WINDOW_HEIGHT)
-	WWG.OnWindowResize("stop")
+	WizardsWardrobeWindow:SetWidth( WINDOW_WIDTH )
+	WizardsWardrobeWindow:SetHeight( WINDOW_HEIGHT )
+	WWG.OnWindowResize( "stop" )
 end
 
 function WWG.SetupPanel()
-	WizardsWardrobePanel.fragment = ZO_SimpleSceneFragment:New(WizardsWardrobePanel)
-	WizardsWardrobePanel.fragment:SetConditional(function()
-		return not WW.settings.panel.hidden and not IsUnitDead("player")
-	end)
-	HUD_SCENE:AddFragment(WizardsWardrobePanel.fragment)
-	HUD_UI_SCENE:AddFragment(WizardsWardrobePanel.fragment)
-	zo_callLater(function() WizardsWardrobePanel.fragment:Refresh() end, 1)
-	
-	WizardsWardrobePanelIcon:SetHandler("OnMouseEnter", function(self)
-		self:SetDesaturation(0.4)
-	end)
-	WizardsWardrobePanelIcon:SetHandler("OnMouseExit", function(self)
-		self:SetDesaturation(0)
-	end)
-	WizardsWardrobePanelIcon:SetHandler("OnMouseDown", function(self)
-		self:SetDesaturation(0.8)
-	end)
-	WizardsWardrobePanelIcon:SetHandler("OnMouseUp", function(self, mouseButton)
-		if MouseIsOver(self, 0, 0, 0, 0)
+	WizardsWardrobePanel.fragment = ZO_SimpleSceneFragment:New( WizardsWardrobePanel )
+	WizardsWardrobePanel.fragment:SetConditional( function()
+		return not WW.settings.panel.hidden and not IsUnitDead( "player" )
+	end )
+	HUD_SCENE:AddFragment( WizardsWardrobePanel.fragment )
+	HUD_UI_SCENE:AddFragment( WizardsWardrobePanel.fragment )
+	zo_callLater( function() WizardsWardrobePanel.fragment:Refresh() end, 1 )
+
+	WizardsWardrobePanelIcon:SetHandler( "OnMouseEnter", function( self )
+		self:SetDesaturation( 0.4 )
+	end )
+	WizardsWardrobePanelIcon:SetHandler( "OnMouseExit", function( self )
+		self:SetDesaturation( 0 )
+	end )
+	WizardsWardrobePanelIcon:SetHandler( "OnMouseDown", function( self )
+		self:SetDesaturation( 0.8 )
+	end )
+	WizardsWardrobePanelIcon:SetHandler( "OnMouseUp", function( self, mouseButton )
+		if MouseIsOver( self, 0, 0, 0, 0 )
 			and mouseButton == MOUSE_BUTTON_INDEX_LEFT then
-			
-			SLASH_COMMANDS["/wizard"]()
-			self:SetDesaturation(0.4)
+			SLASH_COMMANDS[ "/wizard" ]()
+			self:SetDesaturation( 0.4 )
 		else
-			self:SetDesaturation(0)
+			self:SetDesaturation( 0 )
 		end
-	end)
-	
-	WizardsWardrobePanelTopLabel:SetText(WW.displayName:upper())
-	WizardsWardrobePanelMiddleLabel:SetText("Version " .. WW.version)
-	WizardsWardrobePanelBottomLabel:SetText("@ownedbynico")
-	
+	end )
+
+	WizardsWardrobePanelTopLabel:SetText( WW.displayName:upper() )
+	WizardsWardrobePanelMiddleLabel:SetText( "Version " .. WW.version )
+	WizardsWardrobePanelBottomLabel:SetText( "@ownedbynico" )
+
 	if WW.settings.panel and WW.settings.panel.mini then
-		WizardsWardrobePanel:SetDimensions(PANEL_WIDTH_MINI, PANEL_HEIGHT_MINI)
-		WizardsWardrobePanelBG:SetHidden(true)
-		WizardsWardrobePanelIcon:SetHidden(true)
-		WizardsWardrobePanelTopLabel:SetHidden(true)
-		WizardsWardrobePanelMiddleLabel:SetAnchor(TOPLEFT, WizardsWardrobePanel, TOPLEFT)
-		WizardsWardrobePanelBottomLabel:SetAnchor(BOTTOMLEFT, WizardsWardrobePanel, BOTTOMLEFT)
+		WizardsWardrobePanel:SetDimensions( PANEL_WIDTH_MINI, PANEL_HEIGHT_MINI )
+		WizardsWardrobePanelBG:SetHidden( true )
+		WizardsWardrobePanelIcon:SetHidden( true )
+		WizardsWardrobePanelTopLabel:SetHidden( true )
+		WizardsWardrobePanelMiddleLabel:SetAnchor( TOPLEFT, WizardsWardrobePanel, TOPLEFT )
+		WizardsWardrobePanelBottomLabel:SetAnchor( BOTTOMLEFT, WizardsWardrobePanel, BOTTOMLEFT )
 	end
-	
+
 	if WW.settings.panel and WW.settings.panel.top and WW.settings.panel.setup then
-		WizardsWardrobePanel:SetAnchor(TOPLEFT, GUI_ROOT, TOPLEFT, WW.settings.panel.left, WW.settings.panel.top)
-		WizardsWardrobePanel:SetMovable(not WW.settings.panel.locked)
+		WizardsWardrobePanel:SetAnchor( TOPLEFT, GUI_ROOT, TOPLEFT, WW.settings.panel.left, WW.settings.panel.top )
+		WizardsWardrobePanel:SetMovable( not WW.settings.panel.locked )
 	else
 		WW.settings.panel = {
 			top = PANEL_DEFAULT_TOP,
@@ -304,7 +303,7 @@ function WWG.SetupPanel()
 			hidden = false,
 			setup = true,
 		}
-		WizardsWardrobePanel:SetAnchor(TOPLEFT, GUI_ROOT, TOPLEFT, PANEL_DEFAULT_LEFT, PANEL_DEFAULT_TOP)
+		WizardsWardrobePanel:SetAnchor( TOPLEFT, GUI_ROOT, TOPLEFT, PANEL_DEFAULT_LEFT, PANEL_DEFAULT_TOP )
 	end
 end
 
@@ -313,28 +312,28 @@ function WWG.OnPanelMove()
 	WW.settings.panel.left = WizardsWardrobePanel:GetLeft()
 end
 
-function WWG.SetPanelText(zoneTag, pageName, setupName)
-	local middleText = string.format("%s / %s", zoneTag, pageName)
-	WizardsWardrobePanelMiddleLabel:SetText(middleText)
-	
-	local logColor = IsUnitInCombat("player") and WW.LOGTYPES.INFO or WW.LOGTYPES.NORMAL
-	local middleText = string.format("|c%s%s|r", logColor, setupName)
-	WizardsWardrobePanelBottomLabel:SetText(middleText)
-	
-	if IsUnitInCombat("player") then
-		WW.queue.Push(function()
-			middleText = string.format("|c%s%s|r", WW.LOGTYPES.NORMAL, setupName)
-			WizardsWardrobePanelBottomLabel:SetText(middleText)
-		end)
+function WWG.SetPanelText( zoneTag, pageName, setupName )
+	local middleText = string.format( "%s / %s", zoneTag, pageName )
+	WizardsWardrobePanelMiddleLabel:SetText( middleText )
+
+	local logColor = IsUnitInCombat( "player" ) and WW.LOGTYPES.INFO or WW.LOGTYPES.NORMAL
+	local middleText = string.format( "|c%s%s|r", logColor, setupName )
+	WizardsWardrobePanelBottomLabel:SetText( middleText )
+
+	if IsUnitInCombat( "player" ) then
+		WW.queue.Push( function()
+			middleText = string.format( "|c%s%s|r", WW.LOGTYPES.NORMAL, setupName )
+			WizardsWardrobePanelBottomLabel:SetText( middleText )
+		end )
 	end
 end
 
 function WWG.SetupWindow()
-	WizardsWardrobeWindow.fragment = ZO_SimpleSceneFragment:New(WizardsWardrobeWindow)
-	WizardsWardrobeWindow:SetDimensions(WW.settings.window.wizard.width, WW.settings.window.wizard.height)
-	WizardsWardrobeWindow:SetResizeHandleSize(8)
-	
-	WizardsWardrobeWindowTitleLabel:SetText(WW.displayName:upper())
+	WizardsWardrobeWindow.fragment = ZO_SimpleSceneFragment:New( WizardsWardrobeWindow )
+	WizardsWardrobeWindow:SetDimensions( WW.settings.window.wizard.width, WW.settings.window.wizard.height )
+	WizardsWardrobeWindow:SetResizeHandleSize( 8 )
+
+	WizardsWardrobeWindowTitleLabel:SetText( WW.displayName:upper() )
 end
 
 function WWG.OnWindowMove()
@@ -343,644 +342,647 @@ function WWG.OnWindowMove()
 	if sceneName == "inventory" and KEYBOARD_QUICKSLOT_FRAGMENT:IsShowing() then
 		sceneName = "inventoryQuickslot"
 	end
-	WW.settings.window[sceneName] = {
+	WW.settings.window[ sceneName ] = {
 		top = WizardsWardrobeWindow:GetTop(),
 		left = WizardsWardrobeWindow:GetLeft(),
 		hidden = false,
 	}
 end
 
-function WWG.OnWindowResize(action)
+function WWG.OnWindowResize( action )
 	local function OnResize()
 		local count = #WWG.setupTable
-		local height = WizardsWardrobeWindow:GetHeight() -TITLE_HEIGHT -TOP_MENU_HEIGHT -DIVIDER_HEIGHT -PAGE_MENU_HEIGHT -DIVIDER_HEIGHT -BOTTOM_MENU_HEIGHT
+		local height = WizardsWardrobeWindow:GetHeight() - TITLE_HEIGHT - TOP_MENU_HEIGHT - DIVIDER_HEIGHT - PAGE_MENU_HEIGHT -
+		DIVIDER_HEIGHT - BOTTOM_MENU_HEIGHT
 		local width = WizardsWardrobeWindow:GetWidth() - 6
-		
-		local rows = zo_floor(width / SETUP_BOX_WIDTH)
-		local itemsPerCol = zo_ceil(count / rows)
-		
-		local scrollBox = WizardsWardrobeWindowSetupList:GetNamedChild("ScrollChild")
-		
+
+		local rows = zo_floor( width / SETUP_BOX_WIDTH )
+		local itemsPerCol = zo_ceil( count / rows )
+
+		local scrollBox = WizardsWardrobeWindowSetupList:GetNamedChild( "ScrollChild" )
+
 		for i = 1, #WWG.setupTable do
-			local key = WWG.setupTable[i]
-			local setupControl = WWG.setupPool:AcquireObject(key)
-			local x = zo_floor((i-1) / itemsPerCol) * SETUP_BOX_WIDTH + 3
-			local y = (((i-1) % itemsPerCol) * SETUP_BOX_HEIGHT)
+			local key = WWG.setupTable[ i ]
+			local setupControl = WWG.setupPool:AcquireObject( key )
+			local x = zo_floor( (i - 1) / itemsPerCol ) * SETUP_BOX_WIDTH + 3
+			local y = (((i - 1) % itemsPerCol) * SETUP_BOX_HEIGHT)
 			setupControl:ClearAnchors()
-			setupControl:SetAnchor(TOPLEFT, scrollBox, TOPLEFT, x, y)
+			setupControl:SetAnchor( TOPLEFT, scrollBox, TOPLEFT, x, y )
 		end
-		
+
 		WWG.substituteExplain:ClearAnchors()
-		WWG.substituteExplain:SetAnchor(TOP, scrollBox, TOP, 0, itemsPerCol * SETUP_BOX_HEIGHT + 10)
-		
+		WWG.substituteExplain:SetAnchor( TOP, scrollBox, TOP, 0, itemsPerCol * SETUP_BOX_HEIGHT + 10 )
+
 		WWG.addSetupButton:ClearAnchors()
-		WWG.addSetupButton:SetAnchor(TOP, scrollBox, TOP, 0, itemsPerCol * SETUP_BOX_HEIGHT - 10)
+		WWG.addSetupButton:SetAnchor( TOP, scrollBox, TOP, 0, itemsPerCol * SETUP_BOX_HEIGHT - 10 )
 		WWG.addSetupButtonSpacer:ClearAnchors()
-		WWG.addSetupButtonSpacer:SetAnchor(TOP, scrollBox, TOP, 0, itemsPerCol * SETUP_BOX_HEIGHT + 10)
-		
-		WizardsWardrobeWindowTitle:SetWidth(width)
-		WizardsWardrobeWindowPageMenu:SetWidth(width)
-		WizardsWardrobeWindowSetupList:SetDimensions(width, height)
-		scrollBox:SetDimensionConstraints(width, height, AUTO_SIZE, AUTO_SIZE)
-		WizardsWardrobeWindowBottomMenu:SetWidth(width)
-		
-		WizardsWardrobeWindowTopDivider:SetWidth(width)
-		WizardsWardrobeWindowBottomDivider:SetWidth(width)
+		WWG.addSetupButtonSpacer:SetAnchor( TOP, scrollBox, TOP, 0, itemsPerCol * SETUP_BOX_HEIGHT + 10 )
+
+		WizardsWardrobeWindowTitle:SetWidth( width )
+		WizardsWardrobeWindowPageMenu:SetWidth( width )
+		WizardsWardrobeWindowSetupList:SetDimensions( width, height )
+		scrollBox:SetDimensionConstraints( width, height, AUTO_SIZE, AUTO_SIZE )
+		WizardsWardrobeWindowBottomMenu:SetWidth( width )
+
+		WizardsWardrobeWindowTopDivider:SetWidth( width )
+		WizardsWardrobeWindowBottomDivider:SetWidth( width )
 	end
-	
+
 	local function OnResizeEnd()
-		local rows = zo_floor(((WizardsWardrobeWindow:GetWidth() + 2) / SETUP_BOX_WIDTH) + 0.5)
+		local rows = zo_floor( ((WizardsWardrobeWindow:GetWidth() + 2) / SETUP_BOX_WIDTH) + 0.5 )
 		local width = rows * SETUP_BOX_WIDTH + 10
-		WizardsWardrobeWindow:SetWidth(width)
+		WizardsWardrobeWindow:SetWidth( width )
 		OnResize()
-		
+
 		WW.settings.window.wizard.width = WizardsWardrobeWindow:GetWidth()
 		WW.settings.window.wizard.height = WizardsWardrobeWindow:GetHeight()
 	end
-	
+
 	local identifier = WW.name .. "WindowResize"
 	if action == "start" then
-		EVENT_MANAGER:RegisterForUpdate(identifier, 50, OnResize)
+		EVENT_MANAGER:RegisterForUpdate( identifier, 50, OnResize )
 	elseif action == "stop" then
-		EVENT_MANAGER:UnregisterForUpdate(identifier)
+		EVENT_MANAGER:UnregisterForUpdate( identifier )
 		OnResizeEnd()
 	end
 end
 
 function WWG.SetupTopMenu()
-	WizardsWardrobeWindowTitleHide:SetHandler("OnClicked", function(self)
-		SLASH_COMMANDS["/wizard"]()
-	end)
-	
-	local selection = GridComboBox:New("$(parent)Selection", WizardsWardrobeWindow)
-	selection:SetAnchor(LEFT, WizardsWardrobeWindowTopMenu, LEFT, 16)
-	selection:SetDimensions(208, 16)
-	selection:SetItemsPerRow(4)
-    selection:SetItemSize(49)
-	selection:SetItemSpacing(4)
+	WizardsWardrobeWindowTitleHide:SetHandler( "OnClicked", function( self )
+		SLASH_COMMANDS[ "/wizard" ]()
+	end )
+
+	local selection = GridComboBox:New( "$(parent)Selection", WizardsWardrobeWindow )
+	selection:SetAnchor( LEFT, WizardsWardrobeWindowTopMenu, LEFT, 16 )
+	selection:SetDimensions( 208, 16 )
+	selection:SetItemsPerRow( 4 )
+	selection:SetItemSize( 49 )
+	selection:SetItemSpacing( 4 )
 	selection:ClearItems()
-	for _, zone in ipairs(WWG.GetSortedZoneList()) do
-		selection:AddItem({
+	for _, zone in ipairs( WWG.GetSortedZoneList() ) do
+		selection:AddItem( {
 			label = zone.name,
 			tag = zone.tag,
 			icon = zone.icon,
 			callback = function()
-				WWG.OnZoneSelect(zone)
+				WWG.OnZoneSelect( zone )
 			end,
-		})
+		} )
 	end
 	WWG.zoneSelection = selection
-	
-	WizardsWardrobeWindowTopMenuTeleportTrial:SetHandler("OnClicked", function(self)
+
+	WizardsWardrobeWindowTopMenuTeleportTrial:SetHandler( "OnClicked", function( self )
 		local nodeId = WW.selection.zone.node
 		if nodeId < 0 then return end
-		
-		if IsUnitGrouped("player") then
+
+		if IsUnitGrouped( "player" ) then
 			for i = 1, GetGroupSize() do
-				local groupTag = GetGroupUnitTagByIndex(i)
-				if IsUnitOnline(groupTag) then
-					local zoneId = GetUnitWorldPosition(groupTag)
-					if zoneId == WW.selection.zone.id and CanJumpToGroupMember(groupTag) then
-						local displayName = GetUnitDisplayName(groupTag)
-						WW.Log(GetString(WW_MSG_TELEPORT_PLAYER), WW.LOGTYPES.NORMAL, nil, displayName)
-						JumpToGroupMember(displayName)
+				local groupTag = GetGroupUnitTagByIndex( i )
+				if IsUnitOnline( groupTag ) then
+					local zoneId = GetUnitWorldPosition( groupTag )
+					if zoneId == WW.selection.zone.id and CanJumpToGroupMember( groupTag ) then
+						local displayName = GetUnitDisplayName( groupTag )
+						WW.Log( GetString( WW_MSG_TELEPORT_PLAYER ), WW.LOGTYPES.NORMAL, nil, displayName )
+						JumpToGroupMember( displayName )
 						return
 					end
 				end
 			end
 		end
-		
-		if not HasCompletedFastTravelNodePOI(nodeId) then
-			WW.Log(GetString(WW_MSG_TELEPORT_WAYSHRINE_ERROR), WW.LOGTYPES.ERROR)
+
+		if not HasCompletedFastTravelNodePOI( nodeId ) then
+			WW.Log( GetString( WW_MSG_TELEPORT_WAYSHRINE_ERROR ), WW.LOGTYPES.ERROR )
 			return
 		end
-		
-		WW.Log(GetString(WW_MSG_TELEPORT_WAYSHRINE), WW.LOGTYPES.NORMAL)
-		FastTravelToNode(nodeId)
-	end)
-	WWG.SetTooltip(WizardsWardrobeWindowTopMenuTeleportTrial, TOP, GetString(WW_BUTTON_TELEPORT))
-	
-	WizardsWardrobeWindowTopMenuTeleportHouse:SetHandler("OnClicked", function(self)
-		WW.Log(GetString(WW_MSG_TELEPORT_HOUSE), WW.LOGTYPES.NORMAL)
-		RequestJumpToHouse(GetHousingPrimaryHouse())
-	end)
-	WWG.SetTooltip(WizardsWardrobeWindowTopMenuTeleportHouse, TOP, GetString(WW_BUTTON_TELEPORT))
-	
-	WizardsWardrobeWindowTopMenuAddPage:SetHandler("OnClicked", function(self)
-		WWG.CreatePage(WW.selection.zone)
-	end)
-	WWG.SetTooltip(WizardsWardrobeWindowTopMenuAddPage, TOP, GetString(WW_BUTTON_ADDPAGE))
-	
+
+		WW.Log( GetString( WW_MSG_TELEPORT_WAYSHRINE ), WW.LOGTYPES.NORMAL )
+		FastTravelToNode( nodeId )
+	end )
+	WWG.SetTooltip( WizardsWardrobeWindowTopMenuTeleportTrial, TOP, GetString( WW_BUTTON_TELEPORT ) )
+
+	WizardsWardrobeWindowTopMenuTeleportHouse:SetHandler( "OnClicked", function( self )
+		WW.Log( GetString( WW_MSG_TELEPORT_HOUSE ), WW.LOGTYPES.NORMAL )
+		RequestJumpToHouse( GetHousingPrimaryHouse() )
+	end )
+	WWG.SetTooltip( WizardsWardrobeWindowTopMenuTeleportHouse, TOP, GetString( WW_BUTTON_TELEPORT ) )
+
+	WizardsWardrobeWindowTopMenuAddPage:SetHandler( "OnClicked", function( self )
+		WWG.CreatePage( WW.selection.zone )
+	end )
+	WWG.SetTooltip( WizardsWardrobeWindowTopMenuAddPage, TOP, GetString( WW_BUTTON_ADDPAGE ) )
+
 	local autoEquipTextures = {
-		[true] = "/esoui/art/crafting/smithing_tabicon_armorset_down.dds",
-		[false] = "/esoui/art/crafting/smithing_tabicon_armorset_up.dds"
+		[ true ] = "/esoui/art/crafting/smithing_tabicon_armorset_down.dds",
+		[ false ] = "/esoui/art/crafting/smithing_tabicon_armorset_up.dds"
 	}
 	local autoEquipMessages = {
-		[true] = GetString(WW_MSG_TOGGLEAUTOEQUIP_ON),
-		[false] = GetString(WW_MSG_TOGGLEAUTOEQUIP_OFF)
+		[ true ] = GetString( WW_MSG_TOGGLEAUTOEQUIP_ON ),
+		[ false ] = GetString( WW_MSG_TOGGLEAUTOEQUIP_OFF )
 	}
-	WizardsWardrobeWindowTopMenuAutoEquip:SetHandler("OnClicked", function(self)
+	WizardsWardrobeWindowTopMenuAutoEquip:SetHandler( "OnClicked", function( self )
 		WW.settings.autoEquipSetups = not WW.settings.autoEquipSetups
 		WW.storage.autoEquipSetups = WW.settings.autoEquipSetups
-		self:SetNormalTexture(autoEquipTextures[WW.settings.autoEquipSetups])
-		WW.Log(GetString(WW_MSG_TOGGLEAUTOEQUIP), WW.LOGTYPES.NORMAL, nil, autoEquipMessages[WW.settings.autoEquipSetups])
-	end)
-	WizardsWardrobeWindowTopMenuAutoEquip:SetNormalTexture(autoEquipTextures[WW.settings.autoEquipSetups])
-	WWG.SetTooltip(WizardsWardrobeWindowTopMenuAutoEquip, TOP, GetString(WW_BUTTON_TOGGLEAUTOEQUIP))
+		self:SetNormalTexture( autoEquipTextures[ WW.settings.autoEquipSetups ] )
+		WW.Log( GetString( WW_MSG_TOGGLEAUTOEQUIP ), WW.LOGTYPES.NORMAL, nil, autoEquipMessages[ WW.settings.autoEquipSetups ] )
+	end )
+	WizardsWardrobeWindowTopMenuAutoEquip:SetNormalTexture( autoEquipTextures[ WW.settings.autoEquipSetups ] )
+	WWG.SetTooltip( WizardsWardrobeWindowTopMenuAutoEquip, TOP, GetString( WW_BUTTON_TOGGLEAUTOEQUIP ) )
 end
 
-function WWG.OnZoneSelect(zone)
-	PlaySound(SOUNDS.TABLET_PAGE_TURN)
-	
-	if not WW.pages[zone.tag] then
-		WWG.CreatePage(zone, true)
+function WWG.OnZoneSelect( zone )
+	PlaySound( SOUNDS.TABLET_PAGE_TURN )
+
+	if not WW.pages[ zone.tag ] then
+		WWG.CreatePage( zone, true )
 	end
-	
+
 	WW.selection.zone = zone
-	WW.selection.pageId = WW.pages[zone.tag][0].selected
-	
-	WWG.BuildPage(WW.selection.zone, WW.selection.pageId)
-	
-	WWG.zoneSelection:SetLabel(zone.name)
-	
+	WW.selection.pageId = WW.pages[ zone.tag ][ 0 ].selected
+
+	WWG.BuildPage( WW.selection.zone, WW.selection.pageId )
+
+	WWG.zoneSelection:SetLabel( zone.name )
+
 	local isSubstitute = zone.tag == "SUB"
-	WWG.substituteExplain:SetHidden(not isSubstitute)
-	WWG.addSetupButton:SetHidden(isSubstitute)
-	
+	WWG.substituteExplain:SetHidden( not isSubstitute )
+	WWG.addSetupButton:SetHidden( isSubstitute )
+
 	if zone.tag == "GEN"
 		or zone.tag == "SUB"
 		or zone.tag == "PVP" then
-		
-		WizardsWardrobeWindowTopMenuTeleportTrial:SetHidden(true)
-		WizardsWardrobeWindowTopMenuTeleportHouse:SetHidden(false)
+		WizardsWardrobeWindowTopMenuTeleportTrial:SetHidden( true )
+		WizardsWardrobeWindowTopMenuTeleportHouse:SetHidden( false )
 	else
-		WizardsWardrobeWindowTopMenuTeleportTrial:SetHidden(false)
-		WizardsWardrobeWindowTopMenuTeleportHouse:SetHidden(true)
+		WizardsWardrobeWindowTopMenuTeleportTrial:SetHidden( false )
+		WizardsWardrobeWindowTopMenuTeleportHouse:SetHidden( true )
 	end
-	
-	WizardsWardrobeWindowTopMenuTeleportTrial:SetEnabled(not IsInAvAZone())
-	WizardsWardrobeWindowTopMenuTeleportTrial:SetDesaturation(IsInAvAZone() and 1 or 0)
-	WizardsWardrobeWindowTopMenuTeleportHouse:SetEnabled(not IsInAvAZone())
+
+	WizardsWardrobeWindowTopMenuTeleportTrial:SetEnabled( not IsInAvAZone() )
+	WizardsWardrobeWindowTopMenuTeleportTrial:SetDesaturation( IsInAvAZone() and 1 or 0 )
+	WizardsWardrobeWindowTopMenuTeleportHouse:SetEnabled( not IsInAvAZone() )
 end
 
 function WWG.SetupPageMenu()
-	WizardsWardrobeWindowPageMenuWarning:SetHandler("OnMouseUp", function(self, mouseButton)
+	WizardsWardrobeWindowPageMenuWarning:SetHandler( "OnMouseUp", function( self, mouseButton )
 		if mouseButton == MOUSE_BUTTON_INDEX_LEFT then
-			local missingGear = WW.CheckGear(WW.selection.zone, WW.selection.pageId)
+			local missingGear = WW.CheckGear( WW.selection.zone, WW.selection.pageId )
 			if #missingGear > 0 then
-				local missingGearText = string.format(GetString(WW_MISSING_GEAR_TT), WWG.GearLinkTableToString(missingGear))
-				WWG.SetTooltip(self, TOP, missingGearText)
+				local missingGearText = string.format( GetString( WW_MISSING_GEAR_TT ), WWG.GearLinkTableToString( missingGear ) )
+				WWG.SetTooltip( self, TOP, missingGearText )
 			else
-				self:SetHidden(true)
-				WWG.SetTooltip(self, TOP, nil)
+				self:SetHidden( true )
+				WWG.SetTooltip( self, TOP, nil )
 			end
 		end
-	end)
-	WizardsWardrobeWindowPageMenuDropdown:SetHandler("OnClicked", function(self, mouseButton)
+	end )
+	WizardsWardrobeWindowPageMenuDropdown:SetHandler( "OnClicked", function( self, mouseButton )
 		if mouseButton == MOUSE_BUTTON_INDEX_LEFT then
 			if IsMenuVisible() then
 				ClearMenu()
 			else
-				WWG.ShowPageContextMenu(WizardsWardrobeWindowPageMenuLabel)
+				WWG.ShowPageContextMenu( WizardsWardrobeWindowPageMenuLabel )
 			end
 		end
-	end)
-	WWG.SetTooltip(WizardsWardrobeWindowPageMenuBank, TOP, GetString(WW_BUTTON_BANKING))
-	WizardsWardrobeWindowPageMenuBank:SetHandler("OnClicked", function(self)
+	end )
+	WWG.SetTooltip( WizardsWardrobeWindowPageMenuBank, TOP, GetString( WW_BUTTON_BANKING ) )
+	WizardsWardrobeWindowPageMenuBank:SetHandler( "OnClicked", function( self )
 		if IsShiftKeyDown() then
-			WW.banking.DepositPage(WW.selection.zone, WW.selection.pageId)
+			WW.banking.DepositPage( WW.selection.zone, WW.selection.pageId )
 		else
-			WW.banking.WithdrawPage(WW.selection.zone, WW.selection.pageId)
+			WW.banking.WithdrawPage( WW.selection.zone, WW.selection.pageId )
 		end
-	end)
-	WizardsWardrobeWindowPageMenuLeft:SetHandler("OnClicked", function(self)
+	end )
+	WizardsWardrobeWindowPageMenuLeft:SetHandler( "OnClicked", function( self )
 		WWG.PageLeft()
-	end)
-	WizardsWardrobeWindowPageMenuRight:SetHandler("OnClicked", function(self)
+	end )
+	WizardsWardrobeWindowPageMenuRight:SetHandler( "OnClicked", function( self )
 		WWG.PageRight()
-	end)
+	end )
 end
 
 function WWG.SetupSetupList()
 	-- always show scrollbar (set hidden to false only would show some errors)
 	local oldScrollFunction = ZO_Scroll_UpdateScrollBar
-	ZO_Scroll_UpdateScrollBar = function(self, forceUpdateBarValue)
+	ZO_Scroll_UpdateScrollBar = function( self, forceUpdateBarValue )
 		local _, verticalExtents = self.scroll:GetScrollExtents()
 		if verticalExtents > 0 or self:GetName() ~= "WizardsWardrobeWindowSetupList" then
-			oldScrollFunction(self, forceUpdateBarValue)
+			oldScrollFunction( self, forceUpdateBarValue )
 		else
-			ZO_Scroll_ResetToTop(self)
-			self.scroll:SetFadeGradient(1, 0, 0, 0)
+			ZO_Scroll_ResetToTop( self )
+			self.scroll:SetFadeGradient( 1, 0, 0, 0 )
 			local scrollBarHeight = self.scrollbar:GetHeight() / self.scroll:GetScale()
-			self.scrollbar:SetThumbTextureHeight(scrollBarHeight)
-			self.scrollbar:SetHidden(false)
+			self.scrollbar:SetThumbTextureHeight( scrollBarHeight )
+			self.scrollbar:SetHidden( false )
 		end
 	end
-	
-	local scrollBox = WizardsWardrobeWindowSetupList:GetNamedChild("ScrollChild")
-	WWG.addSetupButton = WWG.CreateButton({
+
+	local scrollBox = WizardsWardrobeWindowSetupList:GetNamedChild( "ScrollChild" )
+	WWG.addSetupButton = WWG.CreateButton( {
 		parent = scrollBox,
 		size = 42,
-		anchor = {TOPLEFT, scrollBox, TOPLEFT},
+		anchor = { TOPLEFT, scrollBox, TOPLEFT },
 		texture = "/esoui/art/buttons/plus",
-		tooltip = GetString(WW_BUTTON_ADDSETUP),
+		tooltip = GetString( WW_BUTTON_ADDSETUP ),
 		clicked = function() WWG.CreateSetup() end,
-	})
-	WWG.addSetupButtonSpacer = WWG.CreateLabel({
+	} )
+	WWG.addSetupButtonSpacer = WWG.CreateLabel( {
 		parent = scrollBox,
 		font = "ZoFontGame",
 		text = " ",
-		anchor = {TOPLEFT, scrollBox, TOPLEFT},
-	})
-	WWG.substituteExplain = WWG.CreateLabel({
+		anchor = { TOPLEFT, scrollBox, TOPLEFT },
+	} )
+	WWG.substituteExplain = WWG.CreateLabel( {
 		parent = scrollBox,
 		font = "ZoFontGame",
-		text = GetString(WW_SUBSTITUTE_EXPLAIN),
+		text = GetString( WW_SUBSTITUTE_EXPLAIN ),
 		constraint = 310,
-		anchor = {TOPLEFT, scrollBox, TOPLEFT},
+		anchor = { TOPLEFT, scrollBox, TOPLEFT },
 		hidden = true,
-	})
+	} )
 end
 
 function WWG.SetupBottomMenu()
-	WWG.SetTooltip(WizardsWardrobeWindowBottomMenuSettings, TOP, GetString(WW_BUTTON_SETTINGS))
-	WizardsWardrobeWindowBottomMenuSettings:SetHandler("OnClicked", function(self)
-		LibAddonMenu2:OpenToPanel(WW.menu.panel)
-	end)
-	WWG.SetTooltip(WizardsWardrobeWindowBottomMenuQueue, TOP, GetString(WW_BUTTON_CLEARQUEUE))
-	WizardsWardrobeWindowBottomMenuQueue:SetHandler("OnClicked", function(self)
+	WWG.SetTooltip( WizardsWardrobeWindowBottomMenuSettings, TOP, GetString( WW_BUTTON_SETTINGS ) )
+	WizardsWardrobeWindowBottomMenuSettings:SetHandler( "OnClicked", function( self )
+		LibAddonMenu2:OpenToPanel( WW.menu.panel )
+	end )
+	WWG.SetTooltip( WizardsWardrobeWindowBottomMenuQueue, TOP, GetString( WW_BUTTON_CLEARQUEUE ) )
+	WizardsWardrobeWindowBottomMenuQueue:SetHandler( "OnClicked", function( self )
 		local entries = WW.queue.Size()
 		WW.queue.Reset()
-		WW.Log(GetString(WW_MSG_CLEARQUEUE), WW.LOGTYPES.NORMAL, nil, entries)
-	end)
-	WWG.SetTooltip(WizardsWardrobeWindowBottomMenuUndress, TOP, GetString(WW_BUTTON_UNDRESS))
-	WizardsWardrobeWindowBottomMenuUndress:SetHandler("OnClicked", function(self)
+		WW.Log( GetString( WW_MSG_CLEARQUEUE ), WW.LOGTYPES.NORMAL, nil, entries )
+	end )
+	WWG.SetTooltip( WizardsWardrobeWindowBottomMenuUndress, TOP, GetString( WW_BUTTON_UNDRESS ) )
+	WizardsWardrobeWindowBottomMenuUndress:SetHandler( "OnClicked", function( self )
 		WW.Undress()
-	end)
-	WWG.SetTooltip(WizardsWardrobeWindowBottomMenuPrebuff, TOP, GetString(WW_BUTTON_PREBUFF))
-	WizardsWardrobeWindowBottomMenuPrebuff:SetHandler("OnClicked", function(self)
-		WW.prebuff.dialog:SetHidden(false)
-	end)
-	WWG.SetTooltip(WizardsWardrobeWindowBottomMenuHelp, TOP, GetString(WW_BUTTON_HELP))
-	WizardsWardrobeWindowBottomMenuHelp:SetHandler("OnClicked", function(self)
-		RequestOpenUnsafeURL("https://github.com/nicokimmel/wizardswardrobe/wiki")
-	end)
+	end )
+	WWG.SetTooltip( WizardsWardrobeWindowBottomMenuPrebuff, TOP, GetString( WW_BUTTON_PREBUFF ) )
+	WizardsWardrobeWindowBottomMenuPrebuff:SetHandler( "OnClicked", function( self )
+		WW.prebuff.dialog:SetHidden( false )
+	end )
+	WWG.SetTooltip( WizardsWardrobeWindowBottomMenuHelp, TOP, GetString( WW_BUTTON_HELP ) )
+	WizardsWardrobeWindowBottomMenuHelp:SetHandler( "OnClicked", function( self )
+		RequestOpenUnsafeURL( "https://github.com/nicokimmel/wizardswardrobe/wiki" )
+	end )
 end
 
-function WWG.CreateButton(data)
-	local button = WINDOW_MANAGER:CreateControl(data.name, data.parent, CT_BUTTON)
-	button:SetDimensions(data.size, data.size)
-	button:SetAnchor(unpack(data.anchor))
-	button:SetHidden(data.hidden or false)
-	button:SetClickSound(SOUNDS.DEFAULT_CLICK)
-	button:SetNormalTexture(data.texture .. "_up.dds")
-	button:SetMouseOverTexture(data.texture .. "_over.dds")
-	button:SetPressedTexture(data.texture .. "_down.dds")
-	button:SetDisabledTexture(data.texture .. "_disabled.dds")
-	if data.clicked then button:SetHandler("OnClicked", data.clicked) end
-	if data.tooltip then WWG.SetTooltip(button, TOP, data.tooltip) end
+function WWG.CreateButton( data )
+	local button = WINDOW_MANAGER:CreateControl( data.name, data.parent, CT_BUTTON )
+	button:SetDimensions( data.size, data.size )
+	button:SetAnchor( unpack( data.anchor ) )
+	button:SetHidden( data.hidden or false )
+	button:SetClickSound( SOUNDS.DEFAULT_CLICK )
+	button:SetNormalTexture( data.texture .. "_up.dds" )
+	button:SetMouseOverTexture( data.texture .. "_over.dds" )
+	button:SetPressedTexture( data.texture .. "_down.dds" )
+	button:SetDisabledTexture( data.texture .. "_disabled.dds" )
+	if data.clicked then button:SetHandler( "OnClicked", data.clicked ) end
+	if data.tooltip then WWG.SetTooltip( button, TOP, data.tooltip ) end
 	return button
 end
 
-function WWG.CreateLabel(data)
-	local label = WINDOW_MANAGER:CreateControl(data.name, data.parent, CT_LABEL)
-	label:SetFont(data.font)
-	label:SetText(data.text or "")
-	label:SetAnchor(unpack(data.anchor))
-	label:SetDimensionConstraints(AUTO_SIZE, AUTO_SIZE, data.constraint or AUTO_SIZE, data.oneline and label:GetFontHeight() or AUTO_SIZE)
-	label:SetHidden(data.hidden or false)
-	label:SetMouseEnabled(data.mouse or false)
-	if data.tooltip then WWG.SetTooltip(label, TOP, data.tooltip) end
+function WWG.CreateLabel( data )
+	local label = WINDOW_MANAGER:CreateControl( data.name, data.parent, CT_LABEL )
+	label:SetFont( data.font )
+	label:SetText( data.text or "" )
+	label:SetAnchor( unpack( data.anchor ) )
+	label:SetDimensionConstraints( AUTO_SIZE, AUTO_SIZE, data.constraint or AUTO_SIZE,
+		data.oneline and label:GetFontHeight() or AUTO_SIZE )
+	label:SetHidden( data.hidden or false )
+	label:SetMouseEnabled( data.mouse or false )
+	if data.tooltip then WWG.SetTooltip( label, TOP, data.tooltip ) end
 	return label
 end
 
 function WWG.CreateSetupPool()
-	local scrollBox = WizardsWardrobeWindowSetupList:GetNamedChild("ScrollChild")
-	
+	local scrollBox = WizardsWardrobeWindowSetupList:GetNamedChild( "ScrollChild" )
+
 	local function FactoryItem()
-        local setup = WINDOW_MANAGER:CreateControl(nil, scrollBox, CT_CONTROL)
-		setup:SetDimensions(SETUP_BOX_WIDTH, SETUP_BOX_HEIGHT)
-		
-		setup.name = WWG.CreateLabel({
+		local setup = WINDOW_MANAGER:CreateControl( nil, scrollBox, CT_CONTROL )
+		setup:SetDimensions( SETUP_BOX_WIDTH, SETUP_BOX_HEIGHT )
+
+		setup.name = WWG.CreateLabel( {
 			parent = setup,
 			font = "ZoFontWinH4",
-			anchor = {TOPLEFT, setup, TOPLEFT},
+			anchor = { TOPLEFT, setup, TOPLEFT },
 			constraint = 252,
 			oneline = true,
 			mouse = true,
-		})
-		setup.dropdown = WWG.CreateButton({
+		} )
+		setup.dropdown = WWG.CreateButton( {
 			parent = setup,
 			size = 16,
-			anchor = {LEFT, setup.name, RIGHT, 2, 0},
+			anchor = { LEFT, setup.name, RIGHT, 2, 0 },
 			texture = "/esoui/art/buttons/scrollbox_downarrow",
-		})
-		setup.modify = WWG.CreateButton({
+		} )
+		setup.modify = WWG.CreateButton( {
 			parent = setup,
 			size = 32,
-			anchor = {TOPRIGHT, setup, TOPRIGHT, -8, -8},
+			anchor = { TOPRIGHT, setup, TOPRIGHT, -8, -8 },
 			texture = "/esoui/art/buttons/edit",
-			tooltip = GetString(WW_BUTTON_MODIFY),
-		})
-		setup.save = WWG.CreateButton({
+			tooltip = GetString( WW_BUTTON_MODIFY ),
+		} )
+		setup.save = WWG.CreateButton( {
 			parent = setup,
 			size = 32,
-			anchor = {RIGHT, setup.modify, LEFT, 8},
+			anchor = { RIGHT, setup.modify, LEFT, 8 },
 			texture = "/esoui/art/buttons/edit_save",
-			tooltip = GetString(WW_BUTTON_SAVE),
-		})
-		setup.preview = WWG.CreateButton({
+			tooltip = GetString( WW_BUTTON_SAVE ),
+		} )
+		setup.preview = WWG.CreateButton( {
 			parent = setup,
 			size = 32,
-			anchor = {RIGHT, setup.save, LEFT, 6, 2},
+			anchor = { RIGHT, setup.save, LEFT, 6, 2 },
 			texture = "/esoui/art/guild/tabicon_roster",
-			tooltip = GetString(WW_BUTTON_PREVIEW),
-		})
-		setup.banking = WWG.CreateButton({
+			tooltip = GetString( WW_BUTTON_PREVIEW ),
+		} )
+		setup.banking = WWG.CreateButton( {
 			parent = setup,
 			hidden = true,
 			size = 34,
-			anchor = {RIGHT, setup.preview, LEFT, 6},
+			anchor = { RIGHT, setup.preview, LEFT, 6 },
 			texture = "/esoui/art/icons/guildranks/guild_indexicon_misc09",
-			tooltip = GetString(WW_BUTTON_BANKING),
-		})
-		
-		local skills = { [0] = {}, [1] = {} }
+			tooltip = GetString( WW_BUTTON_BANKING ),
+		} )
+
+		local skills = { [ 0 ] = {}, [ 1 ] = {} }
 		for hotbarCategory = 0, 1 do
 			for slotIndex = 3, 8 do
 				local x = (slotIndex - 3) * 42
 				local y = hotbarCategory * 42 + 25
-				
-				local skill = WINDOW_MANAGER:CreateControl(nil, setup, CT_TEXTURE)
-				skill:SetDrawLayer(DL_CONTROLS)
-				skill:SetDimensions(40, 40)
-				skill:SetAnchor(TOPLEFT, setup, TOPLEFT, x, y)
-				skill:SetDrawLevel(2)
-				skill:SetMouseEnabled(true)
-				skill:SetTexture("/esoui/art/itemtooltip/eso_itemtooltip_emptyslot.dds")
-				skills[hotbarCategory][slotIndex] = skill
-				
-				local frame = WINDOW_MANAGER:CreateControl(nil, skill, CT_TEXTURE)
-				frame:SetDrawLayer(DL_CONTROLS)
-				frame:SetDimensions(40, 40)
-				frame:SetAnchor(CENTER, skill, CENTER, 0, 0)
-				frame:SetDrawLevel(3)
-				frame:SetTexture("/esoui/art/actionbar/abilityframe64_up.dds")
+
+				local skill = WINDOW_MANAGER:CreateControl( nil, setup, CT_TEXTURE )
+				skill:SetDrawLayer( DL_CONTROLS )
+				skill:SetDimensions( 40, 40 )
+				skill:SetAnchor( TOPLEFT, setup, TOPLEFT, x, y )
+				skill:SetDrawLevel( 2 )
+				skill:SetMouseEnabled( true )
+				skill:SetTexture( "/esoui/art/itemtooltip/eso_itemtooltip_emptyslot.dds" )
+				skills[ hotbarCategory ][ slotIndex ] = skill
+
+				local frame = WINDOW_MANAGER:CreateControl( nil, skill, CT_TEXTURE )
+				frame:SetDrawLayer( DL_CONTROLS )
+				frame:SetDimensions( 40, 40 )
+				frame:SetAnchor( CENTER, skill, CENTER, 0, 0 )
+				frame:SetDrawLevel( 3 )
+				frame:SetTexture( "/esoui/art/actionbar/abilityframe64_up.dds" )
 			end
 		end
 		setup.skills = skills
-		
+
 		local x = 6 * 42
 		local y = 25
-		
-		setup.food = WWG.CreateButton({
+
+		setup.food = WWG.CreateButton( {
 			parent = setup,
 			size = 42,
-			anchor = {TOPLEFT, setup, TOPLEFT, x + 1, y - 1},
+			anchor = { TOPLEFT, setup, TOPLEFT, x + 1, y - 1 },
 			texture = "/esoui/art/crafting/provisioner_indexicon_meat",
-		})
-		local foodFrame = WINDOW_MANAGER:CreateControl(nil, setup.food, CT_TEXTURE)
-		foodFrame:SetDimensions(40, 40)
-		foodFrame:SetAnchor(CENTER, setup.food, CENTER, 0, 0)
-		foodFrame:SetTexture("/esoui/art/actionbar/abilityframe64_up.dds")
-		
-		setup.gear = WWG.CreateButton({
+		} )
+		local foodFrame = WINDOW_MANAGER:CreateControl( nil, setup.food, CT_TEXTURE )
+		foodFrame:SetDimensions( 40, 40 )
+		foodFrame:SetAnchor( CENTER, setup.food, CENTER, 0, 0 )
+		foodFrame:SetTexture( "/esoui/art/actionbar/abilityframe64_up.dds" )
+
+		setup.gear = WWG.CreateButton( {
 			parent = setup,
 			size = 42,
-			anchor = {TOPLEFT, setup, TOPLEFT, x + 42, y - 1},
+			anchor = { TOPLEFT, setup, TOPLEFT, x + 42, y - 1 },
 			texture = "/esoui/art/guild/tabicon_heraldry",
-		})
-		local gearFrame = WINDOW_MANAGER:CreateControl(nil, setup.gear, CT_TEXTURE)
-		gearFrame:SetDimensions(40, 40)
-		gearFrame:SetAnchor(CENTER, setup.gear, CENTER, 0, 0)
-		gearFrame:SetTexture("/esoui/art/actionbar/abilityframe64_up.dds")
-		
-		setup.skill = WWG.CreateButton({
+		} )
+		local gearFrame = WINDOW_MANAGER:CreateControl( nil, setup.gear, CT_TEXTURE )
+		gearFrame:SetDimensions( 40, 40 )
+		gearFrame:SetAnchor( CENTER, setup.gear, CENTER, 0, 0 )
+		gearFrame:SetTexture( "/esoui/art/actionbar/abilityframe64_up.dds" )
+
+		setup.skill = WWG.CreateButton( {
 			parent = setup,
 			size = 44,
-			anchor = {TOPLEFT, setup, TOPLEFT, x, y + 42 - 2},
+			anchor = { TOPLEFT, setup, TOPLEFT, x, y + 42 - 2 },
 			texture = "/esoui/art/mainmenu/menubar_skills",
-		})
-		local skillFrame = WINDOW_MANAGER:CreateControl(nil, setup.skill, CT_TEXTURE)
-		skillFrame:SetDimensions(40, 40)
-		skillFrame:SetAnchor(CENTER, setup.skill, CENTER, 0, 0)
-		skillFrame:SetTexture("/esoui/art/actionbar/abilityframe64_up.dds")
-		
-		setup.cp = WWG.CreateButton({
+		} )
+		local skillFrame = WINDOW_MANAGER:CreateControl( nil, setup.skill, CT_TEXTURE )
+		skillFrame:SetDimensions( 40, 40 )
+		skillFrame:SetAnchor( CENTER, setup.skill, CENTER, 0, 0 )
+		skillFrame:SetTexture( "/esoui/art/actionbar/abilityframe64_up.dds" )
+
+		setup.cp = WWG.CreateButton( {
 			parent = setup,
 			size = 40,
-			anchor = {TOPLEFT, setup, TOPLEFT, x + 42 + 1, y + 42},
+			anchor = { TOPLEFT, setup, TOPLEFT, x + 42 + 1, y + 42 },
 			texture = "/esoui/art/mainmenu/menubar_champion",
-		})
-		local cpFrame = WINDOW_MANAGER:CreateControl(nil, setup.cp, CT_TEXTURE)
-		cpFrame:SetDimensions(40, 40)
-		cpFrame:SetAnchor(CENTER, setup.cp, CENTER, 0, 0)
-		cpFrame:SetTexture("/esoui/art/actionbar/abilityframe64_up.dds")
-		
-        return setup
-    end
-    local function ResetItem(setup)
-        setup:SetHidden(true)
-    end
-    
-    WWG.setupPool = ZO_ObjectPool:New(FactoryItem, ResetItem)
+		} )
+		local cpFrame = WINDOW_MANAGER:CreateControl( nil, setup.cp, CT_TEXTURE )
+		cpFrame:SetDimensions( 40, 40 )
+		cpFrame:SetAnchor( CENTER, setup.cp, CENTER, 0, 0 )
+		cpFrame:SetTexture( "/esoui/art/actionbar/abilityframe64_up.dds" )
+
+		return setup
+	end
+	local function ResetItem( setup )
+		setup:SetHidden( true )
+	end
+
+	WWG.setupPool = ZO_ObjectPool:New( FactoryItem, ResetItem )
 end
 
-function WWG.AquireSetupControl(setup)
+function WWG.AquireSetupControl( setup )
 	local setupControl, key = WWG.setupPool:AcquireObject()
-	table.insert(WWG.setupTable, key)
+	table.insert( WWG.setupTable, key )
 	local index = #WWG.setupTable
-	
-	setupControl:SetHidden(false)
+
+	setupControl:SetHidden( false )
 	setupControl.i = index
-	
-	setupControl.name:SetHandler("OnMouseEnter", function(self)
-		setup = Setup:FromStorage(WW.selection.zone.tag, WW.selection.pageId, index)
-		ZO_Tooltips_ShowTextTooltip(self, TOP, GetString(WW_BUTTON_LABEL))
+
+	setupControl.name:SetHandler( "OnMouseEnter", function( self )
+		setup = Setup:FromStorage( WW.selection.zone.tag, WW.selection.pageId, index )
+		ZO_Tooltips_ShowTextTooltip( self, TOP, GetString( WW_BUTTON_LABEL ) )
 		if not setup:IsDisabled() then
-		 	self:SetColor(1, 0.5, 0.5, 1)
+			self:SetColor( 1, 0.5, 0.5, 1 )
 		end
-	end)
-	setupControl.name:SetHandler("OnMouseExit", function(self)
-		setup = Setup:FromStorage(WW.selection.zone.tag, WW.selection.pageId, index)
+	end )
+	setupControl.name:SetHandler( "OnMouseExit", function( self )
+		setup = Setup:FromStorage( WW.selection.zone.tag, WW.selection.pageId, index )
 		ZO_Tooltips_HideTextTooltip()
 		local color = 1
 		if setup:IsDisabled() then
-		 	color = 0.3
+			color = 0.3
 		end
-		self:SetColor(color, color, color, 1)
-	end)
-	setupControl.name:SetHandler("OnMouseDown", function(self)
-		self:SetColor(0.8, 0.4, 0.4, 1)
-	end)
-	setupControl.name:SetHandler("OnMouseUp", function(self, mouseButton)
-		if not MouseIsOver(self, 0, 0, 0, 0) then return end
+		self:SetColor( color, color, color, 1 )
+	end )
+	setupControl.name:SetHandler( "OnMouseDown", function( self )
+		self:SetColor( 0.8, 0.4, 0.4, 1 )
+	end )
+	setupControl.name:SetHandler( "OnMouseUp", function( self, mouseButton )
+		if not MouseIsOver( self, 0, 0, 0, 0 ) then return end
 		if mouseButton == MOUSE_BUTTON_INDEX_LEFT then
-			WW.LoadSetupCurrent(index, false)
+			WW.LoadSetupCurrent( index, false )
 		end
-	end)
-	
-	setupControl.dropdown:SetHandler("OnClicked", function(self, mouseButton)
+	end )
+
+	setupControl.dropdown:SetHandler( "OnClicked", function( self, mouseButton )
 		if mouseButton == MOUSE_BUTTON_INDEX_LEFT then
 			if IsMenuVisible() then
 				ClearMenu()
 			else
-				WWG.ShowSetupContextMenu(setupControl.name, index)
+				WWG.ShowSetupContextMenu( setupControl.name, index )
 			end
 		end
-	end)
-	setupControl.modify:SetEnabled(not (WW.selection.zone.tag == "SUB"))
-	setupControl.modify:SetHandler("OnClicked", function(self)
-		WWG.ShowModifyDialog(setupControl, index)
-	end)
-	setupControl.save:SetHandler("OnClicked", function(self)
-		WW.SaveSetup(WW.selection.zone, WW.selection.pageId, index)
-		setup = Setup:FromStorage(WW.selection.zone.tag, WW.selection.pageId, index)
-		WWG.RefreshSetup(setupControl, setup)
-	end)
-	setupControl.preview:SetHandler("OnClicked", function(self)
-		WW.preview.ShowPreviewFromSetup(setup, WW.selection.zone.name)
-	end)
-	setupControl.banking:SetHandler("OnClicked", function(self)
+	end )
+	setupControl.modify:SetEnabled( not (WW.selection.zone.tag == "SUB") )
+	setupControl.modify:SetHandler( "OnClicked", function( self )
+		WWG.ShowModifyDialog( setupControl, index )
+	end )
+	setupControl.save:SetHandler( "OnClicked", function( self )
+		WW.SaveSetup( WW.selection.zone, WW.selection.pageId, index )
+		setup = Setup:FromStorage( WW.selection.zone.tag, WW.selection.pageId, index )
+		WWG.RefreshSetup( setupControl, setup )
+	end )
+	setupControl.preview:SetHandler( "OnClicked", function( self )
+		WW.preview.ShowPreviewFromSetup( setup, WW.selection.zone.name )
+	end )
+	setupControl.banking:SetHandler( "OnClicked", function( self )
 		if IsShiftKeyDown() then
-			WW.banking.DepositSetup(WW.selection.zone, WW.selection.pageId, index)
+			WW.banking.DepositSetup( WW.selection.zone, WW.selection.pageId, index )
 		else
-			WW.banking.WithdrawSetup(WW.selection.zone, WW.selection.pageId, index)
+			WW.banking.WithdrawSetup( WW.selection.zone, WW.selection.pageId, index )
 		end
-	end)
-	
+	end )
+
 	for hotbarCategory = 0, 1 do
 		for slotIndex = 3, 8 do
-			local skillControl = setupControl.skills[hotbarCategory][slotIndex]
-			local function OnSkillDragStart(self)
-				if IsUnitInCombat("player") then return	end -- would fail at protected call anyway
+			local skillControl = setupControl.skills[ hotbarCategory ][ slotIndex ]
+			local function OnSkillDragStart( self )
+				if IsUnitInCombat( "player" ) then return end -- would fail at protected call anyway
 				if GetCursorContentType() ~= MOUSE_CONTENT_EMPTY then return end
-				
-				setup = Setup:FromStorage(WW.selection.zone.tag, WW.selection.pageId, index)
-				
-				local abilityId = setup:GetSkills()[hotbarCategory][slotIndex]
+
+				setup = Setup:FromStorage( WW.selection.zone.tag, WW.selection.pageId, index )
+
+				local abilityId = setup:GetSkills()[ hotbarCategory ][ slotIndex ]
 				if not abilityId then return end
-				
-				local baseAbilityId = WW.GetBaseAbilityId(abilityId)
+
+				local baseAbilityId = WW.GetBaseAbilityId( abilityId )
 				if not baseAbilityId then return end
-				
-				local skillType, skillLine, skillIndex = GetSpecificSkillAbilityKeysByAbilityId(baseAbilityId)
-				if CallSecureProtected("PickupAbilityBySkillLine", skillType, skillLine, skillIndex) then
-					setup:SetSkill(hotbarCategory, slotIndex, 0)
-					setup:ToStorage(WW.selection.zone.tag, WW.selection.pageId, index)
-					self:GetHandler("OnMouseExit")()
-					WWG.RefreshSetup(setupControl, setup)
+
+				local skillType, skillLine, skillIndex = GetSpecificSkillAbilityKeysByAbilityId( baseAbilityId )
+				if CallSecureProtected( "PickupAbilityBySkillLine", skillType, skillLine, skillIndex ) then
+					setup:SetSkill( hotbarCategory, slotIndex, 0 )
+					setup:ToStorage( WW.selection.zone.tag, WW.selection.pageId, index )
+					self:GetHandler( "OnMouseExit" )()
+					WWG.RefreshSetup( setupControl, setup )
 				end
 			end
-			local function OnSkillDragReceive(self)
+			local function OnSkillDragReceive( self )
 				if GetCursorContentType() ~= MOUSE_CONTENT_ACTION then return end
 				local abilityId = GetCursorAbilityId()
-				
-				local progression = SKILLS_DATA_MANAGER:GetProgressionDataByAbilityId(abilityId)
+
+				local progression = SKILLS_DATA_MANAGER:GetProgressionDataByAbilityId( abilityId )
 				if not progression then return end
-				
+
 				if progression:IsUltimate() and slotIndex < 8 or
 					not progression:IsUltimate() and slotIndex > 7 then
 					-- Prevent ult on normal slot and vice versa
 					return
 				end
-				
+
 				if progression:IsChainingAbility() then
-					abilityId = GetEffectiveAbilityIdForAbilityOnHotbar(abilityId, hotbarCategory)
+					abilityId = GetEffectiveAbilityIdForAbilityOnHotbar( abilityId, hotbarCategory )
 				end
-				
+
 				ClearCursor()
-				
-				setup = Setup:FromStorage(WW.selection.zone.tag, WW.selection.pageId, index)
-				
-				local previousAbilityId = setup:GetSkills()[hotbarCategory][slotIndex]
-				setup:SetSkill(hotbarCategory, slotIndex, abilityId)
-				setup:ToStorage(WW.selection.zone.tag, WW.selection.pageId, index)
-				
-				self:GetHandler("OnMouseExit")()
-				WWG.RefreshSetup(setupControl, setup)
-				
+
+				setup = Setup:FromStorage( WW.selection.zone.tag, WW.selection.pageId, index )
+
+				local previousAbilityId = setup:GetSkills()[ hotbarCategory ][ slotIndex ]
+				setup:SetSkill( hotbarCategory, slotIndex, abilityId )
+				setup:ToStorage( WW.selection.zone.tag, WW.selection.pageId, index )
+
+				self:GetHandler( "OnMouseExit" )()
+				WWG.RefreshSetup( setupControl, setup )
+
 				if previousAbilityId and previousAbilityId > 0 then
-					local baseAbilityId = WW.GetBaseAbilityId(previousAbilityId)
-					local skillType, skillLine, skillIndex = GetSpecificSkillAbilityKeysByAbilityId(baseAbilityId)
-					CallSecureProtected("PickupAbilityBySkillLine", skillType, skillLine, skillIndex)
+					local baseAbilityId = WW.GetBaseAbilityId( previousAbilityId )
+					local skillType, skillLine, skillIndex = GetSpecificSkillAbilityKeysByAbilityId( baseAbilityId )
+					CallSecureProtected( "PickupAbilityBySkillLine", skillType, skillLine, skillIndex )
 				end
 			end
-			skillControl:SetHandler("OnReceiveDrag", OnSkillDragReceive)
-			skillControl:SetHandler("OnMouseUp", function(self)
-				if MouseIsOver(self, 0, 0, 0, 0) then
-					OnSkillDragReceive(self)
+			skillControl:SetHandler( "OnReceiveDrag", OnSkillDragReceive )
+			skillControl:SetHandler( "OnMouseUp", function( self )
+				if MouseIsOver( self, 0, 0, 0, 0 ) then
+					OnSkillDragReceive( self )
 				end
-			end)
-			skillControl:SetHandler("OnDragStart", OnSkillDragStart)
+			end )
+			skillControl:SetHandler( "OnDragStart", OnSkillDragStart )
 		end
 	end
-	
-	local function OnFoodDrag(self)
+
+	local function OnFoodDrag( self )
 		local cursorContentType = GetCursorContentType()
 		if cursorContentType ~= MOUSE_CONTENT_INVENTORY_ITEM then return false end
-		
+
 		local bagId = GetCursorBagId()
 		local slotIndex = GetCursorSlotIndex()
-		
-		local foodLink = GetItemLink(bagId, slotIndex, LINK_STYLE_DEFAULT)
-		local foodId = GetItemLinkItemId(foodLink)
-		
-		if not WW.BUFFFOOD[foodId] then
-			WW.Log(GetString(WW_MSG_NOTFOOD), WW.LOGTYPES.ERROR)
+
+		local foodLink = GetItemLink( bagId, slotIndex, LINK_STYLE_DEFAULT )
+		local foodId = GetItemLinkItemId( foodLink )
+
+		if not WW.BUFFFOOD[ foodId ] then
+			WW.Log( GetString( WW_MSG_NOTFOOD ), WW.LOGTYPES.ERROR )
 			return false
 		end
-		
-		setup = Setup:FromStorage(WW.selection.zone.tag, WW.selection.pageId, index)
-		
-		WW.SaveFood(setup, slotIndex)
-		setup:ToStorage(WW.selection.zone.tag, WW.selection.pageId, index)
-		
-		self:GetHandler("OnMouseExit")()
-		WWG.RefreshSetup(setupControl, setup)
-		self:GetHandler("OnMouseEnter")()
-		
+
+		setup = Setup:FromStorage( WW.selection.zone.tag, WW.selection.pageId, index )
+
+		WW.SaveFood( setup, slotIndex )
+		setup:ToStorage( WW.selection.zone.tag, WW.selection.pageId, index )
+
+		self:GetHandler( "OnMouseExit" )()
+		WWG.RefreshSetup( setupControl, setup )
+		self:GetHandler( "OnMouseEnter" )()
+
 		ClearCursor()
 		return true
 	end
-	setupControl.food:SetHandler("OnReceiveDrag", OnFoodDrag)
-	setupControl.food:SetHandler("OnClicked", function(self, mouseButton)
-		setup = Setup:FromStorage(WW.selection.zone.tag, WW.selection.pageId, index)
-		if OnFoodDrag(self) then return end
+	setupControl.food:SetHandler( "OnReceiveDrag", OnFoodDrag )
+	setupControl.food:SetHandler( "OnClicked", function( self, mouseButton )
+		setup = Setup:FromStorage( WW.selection.zone.tag, WW.selection.pageId, index )
+		if OnFoodDrag( self ) then return end
 		if mouseButton == MOUSE_BUTTON_INDEX_LEFT then
 			if IsShiftKeyDown() then
-				WW.SaveFood(setup)
-				setup:ToStorage(WW.selection.zone.tag, WW.selection.pageId, index)
-				self:GetHandler("OnMouseExit")()
-				WWG.RefreshSetup(setupControl, setup)
-				self:GetHandler("OnMouseEnter")()
+				WW.SaveFood( setup )
+				setup:ToStorage( WW.selection.zone.tag, WW.selection.pageId, index )
+				self:GetHandler( "OnMouseExit" )()
+				WWG.RefreshSetup( setupControl, setup )
+				self:GetHandler( "OnMouseEnter" )()
 			elseif IsControlKeyDown() or IsCommandKeyDown() then
-				setup:SetFood({})
-				setup:ToStorage(WW.selection.zone.tag, WW.selection.pageId, index)
+				setup:SetFood( {} )
+				setup:ToStorage( WW.selection.zone.tag, WW.selection.pageId, index )
 				ZO_Tooltips_HideTextTooltip()
-				self:GetHandler("OnMouseExit")()
-				WWG.RefreshSetup(setupControl, setup)
-				self:GetHandler("OnMouseEnter")()
+				self:GetHandler( "OnMouseExit" )()
+				WWG.RefreshSetup( setupControl, setup )
+				self:GetHandler( "OnMouseEnter" )()
 			else
-				WW.EatFood(setup)
+				WW.EatFood( setup )
 			end
 		end
-	end)
-	
-	local function OnGearDrag(self)
+	end )
+
+	local function OnGearDrag( self )
 		local cursorContentType = GetCursorContentType()
 		if cursorContentType ~= MOUSE_CONTENT_INVENTORY_ITEM and
-			cursorContentType ~= MOUSE_CONTENT_EQUIPPED_ITEM then return false end
-		
+			cursorContentType ~= MOUSE_CONTENT_EQUIPPED_ITEM then
+			return false
+		end
+
 		local bagId = GetCursorBagId()
 		local slotIndex = GetCursorSlotIndex()
-		
-		local itemLink = GetItemLink(bagId, slotIndex, LINK_STYLE_DEFAULT)
-		local equipType = GetItemLinkEquipType(itemLink)
-		
-		if not WW.GEARTYPE[equipType] then return false end
-		local gearSlot = WW.GEARTYPE[equipType]
-		
+
+		local itemLink = GetItemLink( bagId, slotIndex, LINK_STYLE_DEFAULT )
+		local equipType = GetItemLinkEquipType( itemLink )
+
+		if not WW.GEARTYPE[ equipType ] then return false end
+		local gearSlot = WW.GEARTYPE[ equipType ]
+
 		if IsShiftKeyDown() then
 			if gearSlot == EQUIP_SLOT_MAIN_HAND then
 				gearSlot = EQUIP_SLOT_BACKUP_MAIN
@@ -990,133 +992,133 @@ function WWG.AquireSetupControl(setup)
 				gearSlot = EQUIP_SLOT_BACKUP_POISON
 			end
 		end
-		
-		setup = Setup:FromStorage(WW.selection.zone.tag, WW.selection.pageId, index)
-		
+
+		setup = Setup:FromStorage( WW.selection.zone.tag, WW.selection.pageId, index )
+
 		local gearTable = setup:GetGear()
-		
+
 		if gearTable.mythic then
-			local isMythic = WW.IsMythic(bagId, slotIndex)
+			local isMythic = WW.IsMythic( bagId, slotIndex )
 			if isMythic and gearSlot ~= gearTable.mythic then
-				gearTable[gearTable.mythic] = {
-					["link"] = "",
-					["id"] = "0",
+				gearTable[ gearTable.mythic ] = {
+					[ "link" ] = "",
+					[ "id" ] = "0",
 				}
 				gearTable.mythic = gearSlot
 			elseif not isMythic and gearSlot == gearTable.mythic then
-				gearTable[gearTable.mythic] = {
-					["link"] = "",
-					["id"] = "0",
+				gearTable[ gearTable.mythic ] = {
+					[ "link" ] = "",
+					[ "id" ] = "0",
 				}
 				gearTable.mythic = nil
 			end
 		end
-		
+
 		if gearSlot == EQUIP_SLOT_MAIN_HAND then
-			gearTable[EQUIP_SLOT_OFF_HAND] = {
-				["link"] = "",
-				["id"] = "0",
+			gearTable[ EQUIP_SLOT_OFF_HAND ] = {
+				[ "link" ] = "",
+				[ "id" ] = "0",
 			}
 		elseif gearSlot == EQUIP_SLOT_BACKUP_MAIN then
-			gearTable[EQUIP_SLOT_BACKUP_OFF] = {
-				["link"] = "",
-				["id"] = "0",
+			gearTable[ EQUIP_SLOT_BACKUP_OFF ] = {
+				[ "link" ] = "",
+				[ "id" ] = "0",
 			}
 		end
-		
-		gearTable[gearSlot] = {
-			id = Id64ToString(GetItemUniqueId(bagId, slotIndex)),
-			link = GetItemLink(bagId, slotIndex, LINK_STYLE_DEFAULT),
+
+		gearTable[ gearSlot ] = {
+			id = Id64ToString( GetItemUniqueId( bagId, slotIndex ) ),
+			link = GetItemLink( bagId, slotIndex, LINK_STYLE_DEFAULT ),
 		}
-		
-		if GetItemLinkItemType(gearTable[gearSlot].link) == ITEMTYPE_TABARD then
-			gearTable[gearSlot].creator = GetItemCreatorName(bagId, slotIndex)
+
+		if GetItemLinkItemType( gearTable[ gearSlot ].link ) == ITEMTYPE_TABARD then
+			gearTable[ gearSlot ].creator = GetItemCreatorName( bagId, slotIndex )
 		end
-		
-		setup:SetGear(gearTable)
-		setup:ToStorage(WW.selection.zone.tag, WW.selection.pageId, index)
-		
-		self:GetHandler("OnMouseExit")()
-		WWG.RefreshSetup(setupControl, setup)
-		self:GetHandler("OnMouseEnter")()
-		
+
+		setup:SetGear( gearTable )
+		setup:ToStorage( WW.selection.zone.tag, WW.selection.pageId, index )
+
+		self:GetHandler( "OnMouseExit" )()
+		WWG.RefreshSetup( setupControl, setup )
+		self:GetHandler( "OnMouseEnter" )()
+
 		ClearCursor()
 		return true
 	end
-	setupControl.gear:SetHandler("OnReceiveDrag", OnGearDrag)
-	setupControl.gear:SetHandler("OnClicked", function(self, mouseButton)
-		setup = Setup:FromStorage(WW.selection.zone.tag, WW.selection.pageId, index)
-		if OnGearDrag(self) then return end
+	setupControl.gear:SetHandler( "OnReceiveDrag", OnGearDrag )
+	setupControl.gear:SetHandler( "OnClicked", function( self, mouseButton )
+		setup = Setup:FromStorage( WW.selection.zone.tag, WW.selection.pageId, index )
+		if OnGearDrag( self ) then return end
 		if mouseButton == MOUSE_BUTTON_INDEX_LEFT then
 			if IsShiftKeyDown() then
-				WW.SaveGear(setup)
-				setup:ToStorage(WW.selection.zone.tag, WW.selection.pageId, index)
+				WW.SaveGear( setup )
+				setup:ToStorage( WW.selection.zone.tag, WW.selection.pageId, index )
 				local tooltip = setup:GetGearText()
 				if tooltip and tooltip ~= "" then
-					ZO_Tooltips_ShowTextTooltip(self, RIGHT, tostring(tooltip))
+					ZO_Tooltips_ShowTextTooltip( self, RIGHT, tostring( tooltip ) )
 				end
-				WWG.RefreshSetup(setupControl, setup)
+				WWG.RefreshSetup( setupControl, setup )
 			elseif IsControlKeyDown() or IsCommandKeyDown() then
-				setup:SetGear({mythic = nil})
-				setup:ToStorage(WW.selection.zone.tag, WW.selection.pageId, index)
+				setup:SetGear( { mythic = nil } )
+				setup:ToStorage( WW.selection.zone.tag, WW.selection.pageId, index )
 				ZO_Tooltips_HideTextTooltip()
-				WWG.RefreshSetup(setupControl, setup)
+				WWG.RefreshSetup( setupControl, setup )
 			else
-				WW.LoadGear(setup)
+				WW.LoadGear( setup )
 			end
 		end
-	end)
-	
-	setupControl.skill:SetHandler("OnClicked", function(self, mouseButton)
-		setup = Setup:FromStorage(WW.selection.zone.tag, WW.selection.pageId, index)
+	end )
+
+	setupControl.skill:SetHandler( "OnClicked", function( self, mouseButton )
+		setup = Setup:FromStorage( WW.selection.zone.tag, WW.selection.pageId, index )
 		if mouseButton == MOUSE_BUTTON_INDEX_LEFT then
 			if IsShiftKeyDown() then
-				WW.SaveSkills(setup)
-				setup:ToStorage(WW.selection.zone.tag, WW.selection.pageId, index)
+				WW.SaveSkills( setup )
+				setup:ToStorage( WW.selection.zone.tag, WW.selection.pageId, index )
 				local tooltip = setup:GetSkillsText()
 				if tooltip and tooltip ~= "" then
-					ZO_Tooltips_ShowTextTooltip(self, RIGHT, tostring(tooltip))
+					ZO_Tooltips_ShowTextTooltip( self, RIGHT, tostring( tooltip ) )
 				end
-				WWG.RefreshSetup(setupControl, setup)
+				WWG.RefreshSetup( setupControl, setup )
 			elseif IsControlKeyDown() or IsCommandKeyDown() then
-				setup:SetSkills({[0] = {},[1] = {}})
-				setup:ToStorage(WW.selection.zone.tag, WW.selection.pageId, index)
+				setup:SetSkills( { [ 0 ] = {}, [ 1 ] = {} } )
+				setup:ToStorage( WW.selection.zone.tag, WW.selection.pageId, index )
 				ZO_Tooltips_HideTextTooltip()
-				WWG.RefreshSetup(setupControl, setup)
+				WWG.RefreshSetup( setupControl, setup )
 			else
-				WW.LoadSkills(setup)
+				WW.LoadSkills( setup )
 			end
 		end
-	end)
-	
-	setupControl.cp:SetHandler("OnClicked", function(self, mouseButton)
-		setup = Setup:FromStorage(WW.selection.zone.tag, WW.selection.pageId, index)
+	end )
+
+	setupControl.cp:SetHandler( "OnClicked", function( self, mouseButton )
+		setup = Setup:FromStorage( WW.selection.zone.tag, WW.selection.pageId, index )
 		if mouseButton == MOUSE_BUTTON_INDEX_LEFT then
 			if IsShiftKeyDown() then
-				WW.SaveCP(setup)
-				setup:ToStorage(WW.selection.zone.tag, WW.selection.pageId, index)
+				WW.SaveCP( setup )
+				setup:ToStorage( WW.selection.zone.tag, WW.selection.pageId, index )
 				local tooltip = setup:GetCPText()
 				if tooltip and tooltip ~= "" then
-					ZO_Tooltips_ShowTextTooltip(self, RIGHT, tostring(tooltip))
+					ZO_Tooltips_ShowTextTooltip( self, RIGHT, tostring( tooltip ) )
 				end
-				WWG.RefreshSetup(setupControl, setup)
+				WWG.RefreshSetup( setupControl, setup )
 			elseif IsControlKeyDown() or IsCommandKeyDown() then
-				setup:SetCP({})
-				setup:ToStorage(WW.selection.zone.tag, WW.selection.pageId, index)
+				setup:SetCP( {} )
+				setup:ToStorage( WW.selection.zone.tag, WW.selection.pageId, index )
 				ZO_Tooltips_HideTextTooltip()
-				WWG.RefreshSetup(setupControl, setup)
+				WWG.RefreshSetup( setupControl, setup )
 			else
-				WW.LoadCP(setup)
+				WW.LoadCP( setup )
 			end
 		end
-	end)
-	
+	end )
+
 	return setupControl
 end
 
-function WWG.GetSetupControl(index)
-	local key = WWG.setupTable[index]
-	local setupControl = WWG.setupPool:AcquireObject(key)
+function WWG.GetSetupControl( index )
+	local key = WWG.setupTable[ index ]
+	local setupControl = WWG.setupPool:AcquireObject( key )
 	return setupControl
 end
 
@@ -1124,140 +1126,140 @@ function WWG.CreateSetup()
 	local index = #WWG.setupTable + 1
 	local tag = WW.selection.zone.tag
 	local pageId = WW.selection.pageId
-	
-	local setup = Setup:FromStorage(tag, pageId, index)
-	setup:ToStorage(tag, pageId, index)
-	
-	local control = WWG.AquireSetupControl(setup)
-	WWG.RefreshSetup(control, setup)
-	WWG.OnWindowResize("stop")
+
+	local setup = Setup:FromStorage( tag, pageId, index )
+	setup:ToStorage( tag, pageId, index )
+
+	local control = WWG.AquireSetupControl( setup )
+	WWG.RefreshSetup( control, setup )
+	WWG.OnWindowResize( "stop" )
 end
 
 function WWG.RenameSetup()
-	
+
 end
 
 function WWG.ClearPage()
 	for i = 1, #WWG.setupTable do
-		local key = WWG.setupTable[i]
-		WWG.setupPool:ReleaseObject(key)
+		local key = WWG.setupTable[ i ]
+		WWG.setupPool:ReleaseObject( key )
 	end
 	WWG.setupTable = {}
 end
 
-function WWG.BuildPage(zone, pageId, scroll)
+function WWG.BuildPage( zone, pageId, scroll )
 	WWG.ClearPage()
-	for entry in WW.PageIterator(zone, pageId) do
-		local setup = Setup:FromStorage(zone.tag, pageId, entry.index)
-		local control = WWG.AquireSetupControl(setup)
+	for entry in WW.PageIterator( zone, pageId ) do
+		local setup = Setup:FromStorage( zone.tag, pageId, entry.index )
+		local control = WWG.AquireSetupControl( setup )
 	end
 	if zone.tag == "SUB" and #WWG.setupTable == 0 then
-		WWG.CreateDefaultSetups(zone, pageId)
-		WWG.BuildPage(zone, pageId)
+		WWG.CreateDefaultSetups( zone, pageId )
+		WWG.BuildPage( zone, pageId )
 		return
 	end
 	WWG.RefreshPage()
-	WWG.OnWindowResize("stop")
+	WWG.OnWindowResize( "stop" )
 	WW.conditions.LoadConditions()
 	if scroll then
-		ZO_Scroll_ResetToTop(WizardsWardrobeWindowSetupList)
+		ZO_Scroll_ResetToTop( WizardsWardrobeWindowSetupList )
 	end
 end
 
-function WWG.CreatePage(zone, skipBuilding)
-	if not WW.pages[zone.tag] then
-		WW.pages[zone.tag] = {}
-		WW.pages[zone.tag][0] = {}
-		WW.pages[zone.tag][0].selected = 1
+function WWG.CreatePage( zone, skipBuilding )
+	if not WW.pages[ zone.tag ] then
+		WW.pages[ zone.tag ] = {}
+		WW.pages[ zone.tag ][ 0 ] = {}
+		WW.pages[ zone.tag ][ 0 ].selected = 1
 	end
-	
-	local nextPageId = #WW.pages[zone.tag] + 1
-	WW.pages[zone.tag][nextPageId] = {
-		name = string.format(GetString(WW_PAGE), tostring(nextPageId)),
+
+	local nextPageId = #WW.pages[ zone.tag ] + 1
+	WW.pages[ zone.tag ][ nextPageId ] = {
+		name = string.format( GetString( WW_PAGE ), tostring( nextPageId ) ),
 	}
-	
-	WW.pages[zone.tag][0].selected = nextPageId
+
+	WW.pages[ zone.tag ][ 0 ].selected = nextPageId
 	WW.selection.pageId = nextPageId
-	
-	WWG.CreateDefaultSetups(zone, nextPageId)
-	
+
+	WWG.CreateDefaultSetups( zone, nextPageId )
+
 	if not skipBuilding then
-		WWG.BuildPage(zone, nextPageId, true)
+		WWG.BuildPage( zone, nextPageId, true )
 	end
-	
+
 	return nextPageId
 end
 
-function WWG.CreateDefaultSetups(zone, pageId)
-	for i, boss in ipairs(zone.bosses) do
-		local setup = Setup:FromStorage(zone.tag, pageId, i)
-		setup:SetName(boss.displayName or boss.name)
-		setup:SetCondition({
+function WWG.CreateDefaultSetups( zone, pageId )
+	for i, boss in ipairs( zone.bosses ) do
+		local setup = Setup:FromStorage( zone.tag, pageId, i )
+		setup:SetName( boss.displayName or boss.name )
+		setup:SetCondition( {
 			boss = boss.name,
-			trash = (boss.name == GetString(WW_TRASH)) and WW.CONDITIONS.EVERYWHERE or nil
-		})
-		setup:ToStorage(zone.tag, pageId, i)
+			trash = (boss.name == GetString( WW_TRASH )) and WW.CONDITIONS.EVERYWHERE or nil
+		} )
+		setup:ToStorage( zone.tag, pageId, i )
 	end
 end
 
 function WWG.DuplicatePage()
 	local zone = WW.selection.zone
 	local pageId = WW.selection.pageId
-	
-	local cloneId = WWG.CreatePage(zone, true)
-	
-	local pageName = WW.pages[zone.tag][pageId].name
-	WW.pages[zone.tag][cloneId].name = string.format(GetString(WW_DUPLICATE_NAME), pageName)
-	
-	WW.setups[zone.tag][cloneId] = {}
-	ZO_DeepTableCopy(WW.setups[zone.tag][pageId], WW.setups[zone.tag][cloneId])
-	
-	WWG.BuildPage(WW.selection.zone, WW.selection.pageId, true)
+
+	local cloneId = WWG.CreatePage( zone, true )
+
+	local pageName = WW.pages[ zone.tag ][ pageId ].name
+	WW.pages[ zone.tag ][ cloneId ].name = string.format( GetString( WW_DUPLICATE_NAME ), pageName )
+
+	WW.setups[ zone.tag ][ cloneId ] = {}
+	ZO_DeepTableCopy( WW.setups[ zone.tag ][ pageId ], WW.setups[ zone.tag ][ cloneId ] )
+
+	WWG.BuildPage( WW.selection.zone, WW.selection.pageId, true )
 end
 
 function WWG.DeletePage()
 	local zone = WW.selection.zone
 	local pageId = WW.selection.pageId
-	
+
 	-- this is a workaround for empty pages
 	-- dont ask me why
 	if #WWG.setupTable == 0 then
 		WWG.CreateSetup()
 	end
-	
+
 	local nextPageId = pageId - 1
 	if nextPageId < 1 then nextPageId = pageId end
-	
-	WW.pages[zone.tag][0].selected = nextPageId
+
+	WW.pages[ zone.tag ][ 0 ].selected = nextPageId
 	WW.selection.pageId = nextPageId
-	
-	table.remove(WW.setups[zone.tag], pageId)
-	table.remove(WW.pages[zone.tag], pageId)
-	
+
+	table.remove( WW.setups[ zone.tag ], pageId )
+	table.remove( WW.pages[ zone.tag ], pageId )
+
 	WW.markers.BuildGearList()
-	WWG.BuildPage(zone, nextPageId, true)
-	
+	WWG.BuildPage( zone, nextPageId, true )
+
 	return nextPageId
 end
 
 function WWG.RenamePage()
 	local zone = WW.selection.zone
 	local pageId = WW.selection.pageId
-	
-	local initialText = WW.pages[zone.tag][pageId].name
-	WWG.ShowEditDialog("PageNameEdit", GetString(WW_RENAME_PAGE), initialText,
-	function(input)
-		if not input then
-			return
-		end
-		if input == "" then
-			WW.pages[zone.tag][pageId].name = GetString(WW_UNNAMED)
-		else
-			WW.pages[zone.tag][pageId].name = input
-		end
-		local pageName = WW.pages[zone.tag][pageId].name
-		WizardsWardrobeWindowPageMenuLabel:SetText(pageName:upper())
-	end)
+
+	local initialText = WW.pages[ zone.tag ][ pageId ].name
+	WWG.ShowEditDialog( "PageNameEdit", GetString( WW_RENAME_PAGE ), initialText,
+						function( input )
+							if not input then
+								return
+							end
+							if input == "" then
+								WW.pages[ zone.tag ][ pageId ].name = GetString( WW_UNNAMED )
+							else
+								WW.pages[ zone.tag ][ pageId ].name = input
+							end
+							local pageName = WW.pages[ zone.tag ][ pageId ].name
+							WizardsWardrobeWindowPageMenuLabel:SetText( pageName:upper() )
+						end )
 end
 
 function WWG.PageLeft()
@@ -1266,395 +1268,408 @@ function WWG.PageLeft()
 	end
 	local prevPage = WW.selection.pageId - 1
 	WW.selection.pageId = prevPage
-	WW.pages[WW.selection.zone.tag][0].selected = prevPage
-	WWG.BuildPage(WW.selection.zone, WW.selection.pageId, true)
+	WW.pages[ WW.selection.zone.tag ][ 0 ].selected = prevPage
+	WWG.BuildPage( WW.selection.zone, WW.selection.pageId, true )
 end
 
 function WWG.PageRight()
-	if WW.selection.pageId + 1 > #WW.pages[WW.selection.zone.tag] then
+	if WW.selection.pageId + 1 > #WW.pages[ WW.selection.zone.tag ] then
 		return
 	end
 	local nextPage = WW.selection.pageId + 1
 	WW.selection.pageId = nextPage
-	WW.pages[WW.selection.zone.tag][0].selected = nextPage
-	WWG.BuildPage(WW.selection.zone, WW.selection.pageId, true)
+	WW.pages[ WW.selection.zone.tag ][ 0 ].selected = nextPage
+	WWG.BuildPage( WW.selection.zone, WW.selection.pageId, true )
 end
 
 function WWG.RefreshPage()
 	local zone = WW.selection.zone
 	local pageId = WW.selection.pageId
-	
+
 	for i = 1, #WWG.setupTable do
-		local setupControl = WWG.GetSetupControl(i)
-		local setup = Setup:FromStorage(zone.tag, pageId, i)
-		WWG.RefreshSetup(setupControl, setup)
+		local setupControl = WWG.GetSetupControl( i )
+		local setup = Setup:FromStorage( zone.tag, pageId, i )
+		WWG.RefreshSetup( setupControl, setup )
 	end
-	
-	local pageName = WW.pages[zone.tag][pageId].name
-	WizardsWardrobeWindowPageMenuLabel:SetText(pageName:upper())
-	
-	if pageId == 1 then WizardsWardrobeWindowPageMenuLeft:SetEnabled(false) else WizardsWardrobeWindowPageMenuLeft:SetEnabled(true) end
-	if pageId == #WW.pages[zone.tag] then WizardsWardrobeWindowPageMenuRight:SetEnabled(false) else WizardsWardrobeWindowPageMenuRight:SetEnabled(true) end
-	
-	local missingGear = WW.CheckGear(zone, pageId)
+
+	local pageName = WW.pages[ zone.tag ][ pageId ].name
+	WizardsWardrobeWindowPageMenuLabel:SetText( pageName:upper() )
+
+	if pageId == 1 then WizardsWardrobeWindowPageMenuLeft:SetEnabled( false ) else WizardsWardrobeWindowPageMenuLeft
+			:SetEnabled( true ) end
+	if pageId == #WW.pages[ zone.tag ] then WizardsWardrobeWindowPageMenuRight:SetEnabled( false ) else
+		WizardsWardrobeWindowPageMenuRight:SetEnabled( true ) end
+
+	local missingGear = WW.CheckGear( zone, pageId )
 	if #missingGear > 0 then
-		WizardsWardrobeWindowPageMenuWarning:SetHidden(false)
-		local missingGearText = string.format(GetString(WW_MISSING_GEAR_TT), WWG.GearLinkTableToString(missingGear))
-		WWG.SetTooltip(WizardsWardrobeWindowPageMenuWarning, TOP, missingGearText)
+		WizardsWardrobeWindowPageMenuWarning:SetHidden( false )
+		local missingGearText = string.format( GetString( WW_MISSING_GEAR_TT ), WWG.GearLinkTableToString( missingGear ) )
+		WWG.SetTooltip( WizardsWardrobeWindowPageMenuWarning, TOP, missingGearText )
 	else
-		WizardsWardrobeWindowPageMenuWarning:SetHidden(true)
-		WWG.SetTooltip(WizardsWardrobeWindowPageMenuWarning, TOP, nil)
+		WizardsWardrobeWindowPageMenuWarning:SetHidden( true )
+		WWG.SetTooltip( WizardsWardrobeWindowPageMenuWarning, TOP, nil )
 	end
-	
-	WWG.OnWindowResize("stop")
+
+	WWG.OnWindowResize( "stop" )
 end
 
-function WWG.RefreshSetup(control, setup)
+function WWG.RefreshSetup( control, setup )
 	local color = (setup:IsDisabled() and 0.3 or 1)
-	local name = string.format("|cC5C29E%s|r %s", control.i, setup:GetName():upper())
-	control.name:SetText(name)
-	control.name:SetColor(color, color, color, 1)
-	
+	local name = string.format( "|cC5C29E%s|r %s", control.i, setup:GetName():upper() )
+	control.name:SetText( name )
+	control.name:SetColor( color, color, color, 1 )
+
 	for hotbarCategory = 0, 1 do
 		for slotIndex = 3, 8 do
-			local abilityId = setup:GetSkills()[hotbarCategory][slotIndex]
+			local abilityId = setup:GetSkills()[ hotbarCategory ][ slotIndex ]
 			local abilityIcon = "/esoui/art/itemtooltip/eso_itemtooltip_emptyslot.dds"
 			if abilityId and abilityId > 0 then
-				abilityIcon = GetAbilityIcon(abilityId)
+				abilityIcon = GetAbilityIcon( abilityId )
 			end
-			local skillControl = control.skills[hotbarCategory][slotIndex]
-			skillControl:SetTexture(abilityIcon)
-			skillControl:SetColor(color, color, color, 1)
+			local skillControl = control.skills[ hotbarCategory ][ slotIndex ]
+			skillControl:SetTexture( abilityIcon )
+			skillControl:SetColor( color, color, color, 1 )
 			if abilityId and abilityId > 0 then
-				skillControl:SetHandler("OnMouseEnter", function()
-					InitializeTooltip(AbilityTooltip, skillControl, TOPLEFT, 8, -8, TOPRIGHT)
-					AbilityTooltip:SetAbilityId(abilityId)
-				end)
-				skillControl:SetHandler("OnMouseExit", function()
-					ClearTooltip(AbilityTooltip)
-				end)
+				skillControl:SetHandler( "OnMouseEnter", function()
+					InitializeTooltip( AbilityTooltip, skillControl, TOPLEFT, 8, -8, TOPRIGHT )
+					AbilityTooltip:SetAbilityId( abilityId )
+				end )
+				skillControl:SetHandler( "OnMouseExit", function()
+					ClearTooltip( AbilityTooltip )
+				end )
 			else
-				skillControl:SetHandler("OnMouseEnter", function() end)
-				skillControl:SetHandler("OnMouseExit", function() end)
+				skillControl:SetHandler( "OnMouseEnter", function() end )
+				skillControl:SetHandler( "OnMouseExit", function() end )
 			end
 		end
 	end
-	
+
 	local food = setup:GetFood()
 	if food.link then
-		control.food:SetHandler("OnMouseEnter", function()
-			InitializeTooltip(ItemTooltip, control.food, LEFT, 4, 0, RIGHT)
-			ItemTooltip:SetLink(food.link)
-		end)
-		control.food:SetHandler("OnMouseExit", function()
-			ClearTooltip(ItemTooltip)
-		end)
+		control.food:SetHandler( "OnMouseEnter", function()
+			InitializeTooltip( ItemTooltip, control.food, LEFT, 4, 0, RIGHT )
+			ItemTooltip:SetLink( food.link )
+		end )
+		control.food:SetHandler( "OnMouseExit", function()
+			ClearTooltip( ItemTooltip )
+		end )
 	else
-		WWG.SetTooltip(control.food, RIGHT, GetString(WW_BUTTON_BUFFFOOD))
+		WWG.SetTooltip( control.food, RIGHT, GetString( WW_BUTTON_BUFFFOOD ) )
 	end
-	
+
 	local gearText = setup:GetGearText()
-	WWG.SetTooltip(control.gear, RIGHT, gearText)
-	
+	WWG.SetTooltip( control.gear, RIGHT, gearText )
+
 	local skillsText = setup:GetSkillsText()
-	WWG.SetTooltip(control.skill, RIGHT, skillsText)
-	
+	WWG.SetTooltip( control.skill, RIGHT, skillsText )
+
 	local cpText = setup:GetCPText()
-	WWG.SetTooltip(control.cp, RIGHT, cpText)
-	
-	if IsBankOpen() and not WW.DISABLEDBAGS[GetBankingBag()] then
-		control.banking:SetHidden(false)
-		WizardsWardrobeWindowPageMenuBank:SetHidden(false)
+	WWG.SetTooltip( control.cp, RIGHT, cpText )
+
+	if IsBankOpen() and not WW.DISABLEDBAGS[ GetBankingBag() ] then
+		control.banking:SetHidden( false )
+		WizardsWardrobeWindowPageMenuBank:SetHidden( false )
 	else
-		control.banking:SetHidden(true)
-		WizardsWardrobeWindowPageMenuBank:SetHidden(true)
+		control.banking:SetHidden( true )
+		WizardsWardrobeWindowPageMenuBank:SetHidden( true )
 	end
 end
 
-function WWG.ShowPageContextMenu(control)
+function WWG.ShowPageContextMenu( control )
 	local zone = WW.selection.zone
 	local pageId = WW.selection.pageId
-	
+
 	ClearMenu()
-	
-	AddMenuItem(GetString(WW_BUTTON_RENAME), function() WWG.RenamePage() end, MENU_ADD_OPTION_LABEL)
-	
+
+	AddMenuItem( GetString( WW_BUTTON_RENAME ), function() WWG.RenamePage() end, MENU_ADD_OPTION_LABEL )
+
 	if WW.selection.zone.tag ~= "SUB" then
-		AddMenuItem(GetString(WW_BUTTON_REARRANGE), function() WWG.ShowArrangeDialog(zone, pageId) end, MENU_ADD_OPTION_LABEL)
+		AddMenuItem( GetString( WW_BUTTON_REARRANGE ), function() WWG.ShowArrangeDialog( zone, pageId ) end,
+			MENU_ADD_OPTION_LABEL )
 	end
-	
-	AddMenuItem(GetString(WW_DUPLICATE), function() WWG.DuplicatePage() end, MENU_ADD_OPTION_LABEL)
-	
-	local deleteColor = #WW.pages[zone.tag] > 1 and ZO_ColorDef:New(1, 0, 0, 1) or ZO_ColorDef:New(0.35, 0.35, 0.35, 1)
-	AddMenuItem(GetString(WW_DELETE):upper(), function()
-		if #WW.pages[zone.tag] > 1 then
-			local pageName = WW.pages[zone.tag][pageId].name
-			WWG.ShowConfirmationDialog("DeletePageConfirmation", string.format(GetString(WW_DELETEPAGE_WARNING), pageName),
-			function()
-				WWG.DeletePage()
-			end)
-		end
-	end, MENU_ADD_OPTION_LABEL, "ZoFontGameBold", deleteColor, deleteColor)
-	
+
+	AddMenuItem( GetString( WW_DUPLICATE ), function() WWG.DuplicatePage() end, MENU_ADD_OPTION_LABEL )
+
+	local deleteColor = #WW.pages[ zone.tag ] > 1 and ZO_ColorDef:New( 1, 0, 0, 1 ) or ZO_ColorDef:New( 0.35, 0.35, 0.35, 1 )
+	AddMenuItem( GetString( WW_DELETE ):upper(), function()
+					 if #WW.pages[ zone.tag ] > 1 then
+						 local pageName = WW.pages[ zone.tag ][ pageId ].name
+						 WWG.ShowConfirmationDialog( "DeletePageConfirmation",
+													 string.format( GetString( WW_DELETEPAGE_WARNING ), pageName ),
+													 function()
+														 WWG.DeletePage()
+													 end )
+					 end
+				 end, MENU_ADD_OPTION_LABEL, "ZoFontGameBold", deleteColor, deleteColor )
+
 	-- lets fix some ZOS bugs(?)
 	if control:GetWidth() >= ZO_Menu.width then
-        ZO_Menu.width = control:GetWidth() - 10
-    end
-	
-	ShowMenu(control, 2, MENU_TYPE_COMBO_BOX)
-	SetMenuPad(100)
-	AnchorMenu(control, 0)
+		ZO_Menu.width = control:GetWidth() - 10
+	end
+
+	ShowMenu( control, 2, MENU_TYPE_COMBO_BOX )
+	SetMenuPad( 100 )
+	AnchorMenu( control, 0 )
 end
 
-function WWG.ShowSetupContextMenu(control, index)
+function WWG.ShowSetupContextMenu( control, index )
 	local zone = WW.selection.zone
 	local pageId = WW.selection.pageId
-	
+
 	ClearMenu()
-	
+
 	-- LINK TO CHAT
-	AddMenuItem(GetString(SI_ITEM_ACTION_LINK_TO_CHAT), function()
-		WW.preview.PrintPreviewString(zone, pageId, index)
-	end, MENU_ADD_OPTION_LABEL)
-	
+	AddMenuItem( GetString( SI_ITEM_ACTION_LINK_TO_CHAT ), function()
+					 WW.preview.PrintPreviewString( zone, pageId, index )
+				 end, MENU_ADD_OPTION_LABEL )
+
 	-- CUSTOM CODE
-	AddMenuItem(GetString(WW_CUSTOMCODE), function() WW.code.ShowCodeDialog(zone, pageId, index) end, MENU_ADD_OPTION_LABEL)
-	
+	AddMenuItem( GetString( WW_CUSTOMCODE ), function() WW.code.ShowCodeDialog( zone, pageId, index ) end,
+		MENU_ADD_OPTION_LABEL )
+
 	-- IMPORT / EXPORT
-	AddMenuItem(GetString(WW_IMPORT), function() WW.transfer.ShowImportDialog(zone, pageId, index) end, MENU_ADD_OPTION_LABEL)
-	AddMenuItem(GetString(WW_EXPORT), function() WW.transfer.ShowExportDialog(zone, pageId, index) end, MENU_ADD_OPTION_LABEL)
-	
+	AddMenuItem( GetString( WW_IMPORT ), function() WW.transfer.ShowImportDialog( zone, pageId, index ) end,
+		MENU_ADD_OPTION_LABEL )
+	AddMenuItem( GetString( WW_EXPORT ), function() WW.transfer.ShowExportDialog( zone, pageId, index ) end,
+		MENU_ADD_OPTION_LABEL )
+
 	-- ENABLE / DISABLE
 	--if setup:IsDisabled() then
 	--	AddMenuItem(GetString(WW_ENABLE), function() WWG.SetSetupDisabled(zone, pageId, index, false) end, MENU_ADD_OPTION_LABEL)
 	--else
 	--	AddMenuItem(GetString(WW_DISABLE), function() WWG.SetSetupDisabled(zone, pageId, index, true) end, MENU_ADD_OPTION_LABEL)
 	--end
-	
+
 	-- DELETE
-	AddMenuItem(GetString(WW_DELETE):upper(), function()
-		PlaySound(SOUNDS.DEFER_NOTIFICATION)
-		if WW.selection.zone.tag == "SUB" then
-			WW.ClearSetup(zone, pageId, index)
-		else
-			WW.DeleteSetup(zone, pageId, index)
-		end
-	end, MENU_ADD_OPTION_LABEL, "ZoFontGameBold", ZO_ColorDef:New(1, 0, 0, 1), ZO_ColorDef:New(1, 0, 0, 1))
-	
+	AddMenuItem( GetString( WW_DELETE ):upper(), function()
+					 PlaySound( SOUNDS.DEFER_NOTIFICATION )
+					 if WW.selection.zone.tag == "SUB" then
+						 WW.ClearSetup( zone, pageId, index )
+					 else
+						 WW.DeleteSetup( zone, pageId, index )
+					 end
+				 end, MENU_ADD_OPTION_LABEL, "ZoFontGameBold", ZO_ColorDef:New( 1, 0, 0, 1 ), ZO_ColorDef:New( 1, 0, 0, 1 ) )
+
 	-- lets fix some ZOS bugs(?)
 	if control:GetWidth() >= ZO_Menu.width then
-        ZO_Menu.width = control:GetWidth() - 10
-    end
-	
-	ShowMenu(control, 2, MENU_TYPE_COMBO_BOX)
-	SetMenuPad(100)
-	AnchorMenu(control, 0)
+		ZO_Menu.width = control:GetWidth() - 10
+	end
+
+	ShowMenu( control, 2, MENU_TYPE_COMBO_BOX )
+	SetMenuPad( 100 )
+	AnchorMenu( control, 0 )
 end
 
 function WWG.SetupModifyDialog()
-	WizardsWardrobeModify:SetDimensions(GuiRoot:GetWidth() + 8, GuiRoot:GetHeight() + 8)
-	WizardsWardrobeModifyDialogTitle:SetText(GetString(WW_BUTTON_MODIFY):upper())
-	WizardsWardrobeModifyDialogHide:SetHandler("OnClicked", function(self)
-		WizardsWardrobeModify:SetHidden(true)
-	end)
-	WizardsWardrobeModifyDialogSave:SetText(GetString(WW_BUTTON_SAVE))
-	WizardsWardrobeModifyDialogNameLabel:SetText(GetString(WW_CONDITION_NAME):upper())
-	WizardsWardrobeModifyDialogConditionBossLabel:SetText(GetString(WW_CONDITION_BOSS):upper())
-	WizardsWardrobeModifyDialogConditionTrashLabel:SetText(GetString(WW_CONDITION_AFTER):upper())
-	table.insert(WWG.dialogList, WizardsWardrobeModify)
+	WizardsWardrobeModify:SetDimensions( GuiRoot:GetWidth() + 8, GuiRoot:GetHeight() + 8 )
+	WizardsWardrobeModifyDialogTitle:SetText( GetString( WW_BUTTON_MODIFY ):upper() )
+	WizardsWardrobeModifyDialogHide:SetHandler( "OnClicked", function( self )
+		WizardsWardrobeModify:SetHidden( true )
+	end )
+	WizardsWardrobeModifyDialogSave:SetText( GetString( WW_BUTTON_SAVE ) )
+	WizardsWardrobeModifyDialogNameLabel:SetText( GetString( WW_CONDITION_NAME ):upper() )
+	WizardsWardrobeModifyDialogConditionBossLabel:SetText( GetString( WW_CONDITION_BOSS ):upper() )
+	WizardsWardrobeModifyDialogConditionTrashLabel:SetText( GetString( WW_CONDITION_AFTER ):upper() )
+	table.insert( WWG.dialogList, WizardsWardrobeModify )
 end
 
-function WWG.ShowModifyDialog(setupControl, index)
+function WWG.ShowModifyDialog( setupControl, index )
 	local zone = WW.selection.zone
 	local pageId = WW.selection.pageId
-	
-	local setup = Setup:FromStorage(zone.tag, pageId, index)
-	
+
+	local setup = Setup:FromStorage( zone.tag, pageId, index )
+
 	local condition = setup:GetCondition()
-	
+
 	local newBoss, newTrash
-	
-	WizardsWardrobeModifyDialogNameEdit:SetText(setup:GetName())
-	
+
+	WizardsWardrobeModifyDialogNameEdit:SetText( setup:GetName() )
+
 	if zone.tag == "GEN" then
-		WizardsWardrobeModifyDialogCondition:SetHeight(50)
-		WizardsWardrobeModifyDialogConditionBossCombo:SetHidden(true)
-		WizardsWardrobeModifyDialogConditionBossEdit:SetHidden(false)
-		WizardsWardrobeModifyDialogConditionTrashLabel:SetHidden(true)
-		WizardsWardrobeModifyDialogConditionTrashCombo:SetHidden(true)
-		
-		WizardsWardrobeModifyDialogConditionBossEdit:SetText(condition.boss or "")
-		WizardsWardrobeModifyDialogConditionBossEdit:SetHandler("OnTextChanged", function(self)
+		WizardsWardrobeModifyDialogCondition:SetHeight( 50 )
+		WizardsWardrobeModifyDialogConditionBossCombo:SetHidden( true )
+		WizardsWardrobeModifyDialogConditionBossEdit:SetHidden( false )
+		WizardsWardrobeModifyDialogConditionTrashLabel:SetHidden( true )
+		WizardsWardrobeModifyDialogConditionTrashCombo:SetHidden( true )
+
+		WizardsWardrobeModifyDialogConditionBossEdit:SetText( condition.boss or "" )
+		WizardsWardrobeModifyDialogConditionBossEdit:SetHandler( "OnTextChanged", function( self )
 			newBoss = self:GetText()
-		end)
+		end )
 	else
-		local function OnBossCombo(selection)
+		local function OnBossCombo( selection )
 			newBoss = selection
-			if newBoss == GetString(WW_TRASH) then
-				WizardsWardrobeModifyDialogCondition:SetHeight(100)
-				WizardsWardrobeModifyDialogConditionTrashLabel:SetHidden(false)
-				WizardsWardrobeModifyDialogConditionTrashCombo:SetHidden(false)
+			if newBoss == GetString( WW_TRASH ) then
+				WizardsWardrobeModifyDialogCondition:SetHeight( 100 )
+				WizardsWardrobeModifyDialogConditionTrashLabel:SetHidden( false )
+				WizardsWardrobeModifyDialogConditionTrashCombo:SetHidden( false )
 			else
-				WizardsWardrobeModifyDialogCondition:SetHeight(50)
-				WizardsWardrobeModifyDialogConditionTrashLabel:SetHidden(true)
-				WizardsWardrobeModifyDialogConditionTrashCombo:SetHidden(true)
+				WizardsWardrobeModifyDialogCondition:SetHeight( 50 )
+				WizardsWardrobeModifyDialogConditionTrashLabel:SetHidden( true )
+				WizardsWardrobeModifyDialogConditionTrashCombo:SetHidden( true )
 			end
 		end
-		local function OnTrashCombo(selection)
+		local function OnTrashCombo( selection )
 			newTrash = selection
 		end
-		
-		WizardsWardrobeModifyDialogConditionBossCombo:SetHidden(false)
-		WizardsWardrobeModifyDialogConditionBossEdit:SetHidden(true)
-		
+
+		WizardsWardrobeModifyDialogConditionBossCombo:SetHidden( false )
+		WizardsWardrobeModifyDialogConditionBossEdit:SetHidden( true )
+
 		local bossCombo = WizardsWardrobeModifyDialogConditionBossCombo.m_comboBox
-		bossCombo:SetSortsItems(false)
+		bossCombo:SetSortsItems( false )
 		bossCombo:ClearItems()
-		bossCombo:AddItem(ZO_ComboBox:CreateItemEntry(GetString(WW_CONDITION_NONE), function() OnBossCombo(WW.CONDITIONS.NONE) end))
-		local bossId = zone.lookupBosses[condition.boss]
-		local selectedBoss = bossId and (zone.bosses[bossId].displayName or zone.bosses[bossId].name) or GetString(WW_CONDITION_NONE)
-		bossCombo:SetSelectedItemText(selectedBoss)
-		OnBossCombo(condition.boss or WW.CONDITIONS.NONE)
-		
+		bossCombo:AddItem( ZO_ComboBox:CreateItemEntry( GetString( WW_CONDITION_NONE ),
+			function() OnBossCombo( WW.CONDITIONS.NONE ) end ) )
+		local bossId = zone.lookupBosses[ condition.boss ]
+		local selectedBoss = bossId and (zone.bosses[ bossId ].displayName or zone.bosses[ bossId ].name) or
+		GetString( WW_CONDITION_NONE )
+		bossCombo:SetSelectedItemText( selectedBoss )
+		OnBossCombo( condition.boss or WW.CONDITIONS.NONE )
+
 		local trashCombo = WizardsWardrobeModifyDialogConditionTrashCombo.m_comboBox
-		trashCombo:SetSortsItems(false)
+		trashCombo:SetSortsItems( false )
 		trashCombo:ClearItems()
-		trashCombo:AddItem(ZO_ComboBox:CreateItemEntry(GetString(WW_CONDITION_EVERYWHERE), function() OnTrashCombo(WW.CONDITIONS.EVERYWHERE) end))
-		local trashId = zone.lookupBosses[condition.trash]
-		local selectedTrash = trashId and (zone.bosses[trashId].displayName or zone.bosses[trashId].name) or GetString(WW_CONDITION_EVERYWHERE)
-		trashCombo:SetSelectedItemText(selectedTrash)
-		OnTrashCombo(condition.trash or WW.CONDITIONS.EVERYWHERE)
-		
-		for i, boss in ipairs(zone.bosses) do
-			bossCombo:AddItem(ZO_ComboBox:CreateItemEntry(boss.displayName or boss.name, function() OnBossCombo(boss.name) end))
-			if boss.name ~= GetString(WW_TRASH) then
-				trashCombo:AddItem(ZO_ComboBox:CreateItemEntry(boss.displayName or boss.name, function() OnTrashCombo(boss.name) end))
+		trashCombo:AddItem( ZO_ComboBox:CreateItemEntry( GetString( WW_CONDITION_EVERYWHERE ),
+			function() OnTrashCombo( WW.CONDITIONS.EVERYWHERE ) end ) )
+		local trashId = zone.lookupBosses[ condition.trash ]
+		local selectedTrash = trashId and (zone.bosses[ trashId ].displayName or zone.bosses[ trashId ].name) or
+		GetString( WW_CONDITION_EVERYWHERE )
+		trashCombo:SetSelectedItemText( selectedTrash )
+		OnTrashCombo( condition.trash or WW.CONDITIONS.EVERYWHERE )
+
+		for i, boss in ipairs( zone.bosses ) do
+			bossCombo:AddItem( ZO_ComboBox:CreateItemEntry( boss.displayName or boss.name,
+				function() OnBossCombo( boss.name ) end ) )
+			if boss.name ~= GetString( WW_TRASH ) then
+				trashCombo:AddItem( ZO_ComboBox:CreateItemEntry( boss.displayName or boss.name,
+					function() OnTrashCombo( boss.name ) end ) )
 			end
 		end
 	end
-	
-	WizardsWardrobeModifyDialogSave:SetHandler("OnClicked", function(self)
+
+	WizardsWardrobeModifyDialogSave:SetHandler( "OnClicked", function( self )
 		local newName = WizardsWardrobeModifyDialogNameEdit:GetText()
-		if #newName == 0 then newName = GetString(WW_UNNAMED) end
-		local name = string.format("|cC5C29E%s|r %s", index, newName:upper())
-		setupControl.name:SetText(name)
-		setup:SetName(newName)
-		setup:SetCondition({
+		if #newName == 0 then newName = GetString( WW_UNNAMED ) end
+		local name = string.format( "|cC5C29E%s|r %s", index, newName:upper() )
+		setupControl.name:SetText( name )
+		setup:SetName( newName )
+		setup:SetCondition( {
 			boss = newBoss,
 			trash = newTrash,
-		})
-		setup:ToStorage(zone.tag, pageId, index)
+		} )
+		setup:ToStorage( zone.tag, pageId, index )
 		WW.conditions.LoadConditions()
-		WizardsWardrobeModify:SetHidden(true)
-	end)
-	
-	WizardsWardrobeModify:SetHidden(false)
-	SCENE_MANAGER:SetInUIMode(true, false)
+		WizardsWardrobeModify:SetHidden( true )
+	end )
+
+	WizardsWardrobeModify:SetHidden( false )
+	SCENE_MANAGER:SetInUIMode( true, false )
 end
 
 function WWG.SetupArrangeDialog()
-	WizardsWardrobeArrange:SetDimensions(GuiRoot:GetWidth() + 8, GuiRoot:GetHeight() + 8)
-	WizardsWardrobeArrangeDialogTitle:SetText(GetString(WW_BUTTON_REARRANGE):upper())
-	WizardsWardrobeArrangeDialogSave:SetText(GetString(WW_BUTTON_SAVE))
-	WizardsWardrobeArrangeDialogSave:SetHandler("OnClicked", function(self)
-		local dataList = ZO_ScrollList_GetDataList(WizardsWardrobeArrangeDialogList)
-		WWG.RearrangeSetups(dataList, WW.selection.zone, WW.selection.pageId)
-	end)
-	WizardsWardrobeArrangeDialogHide:SetHandler("OnClicked", function(self)
-		WizardsWardrobeArrange:SetHidden(true)
-	end)
-	WizardsWardrobeArrangeDialogUp:SetHandler("OnClicked", function(self)
-		local index = ZO_ScrollList_GetSelectedDataIndex(WizardsWardrobeArrangeDialogList)
-		
+	WizardsWardrobeArrange:SetDimensions( GuiRoot:GetWidth() + 8, GuiRoot:GetHeight() + 8 )
+	WizardsWardrobeArrangeDialogTitle:SetText( GetString( WW_BUTTON_REARRANGE ):upper() )
+	WizardsWardrobeArrangeDialogSave:SetText( GetString( WW_BUTTON_SAVE ) )
+	WizardsWardrobeArrangeDialogSave:SetHandler( "OnClicked", function( self )
+		local dataList = ZO_ScrollList_GetDataList( WizardsWardrobeArrangeDialogList )
+		WWG.RearrangeSetups( dataList, WW.selection.zone, WW.selection.pageId )
+	end )
+	WizardsWardrobeArrangeDialogHide:SetHandler( "OnClicked", function( self )
+		WizardsWardrobeArrange:SetHidden( true )
+	end )
+	WizardsWardrobeArrangeDialogUp:SetHandler( "OnClicked", function( self )
+		local index = ZO_ScrollList_GetSelectedDataIndex( WizardsWardrobeArrangeDialogList )
+
 		if not index or index == 1 then return end
-		
-		local dataList = ZO_ScrollList_GetDataList(WizardsWardrobeArrangeDialogList)
-		
-		local current = dataList[index]
-		local above = dataList[index - 1]
-		
-		dataList[index] = above
-		dataList[index - 1] = current
-		
-		ZO_ScrollList_Commit(WizardsWardrobeArrangeDialogList)
-		WizardsWardrobeArrangeDialogList:GetNamedChild("ScrollBar"):SetHidden(false)
-	end)
-	WizardsWardrobeArrangeDialogDown:SetHandler("OnClicked", function(self)
-		local index = ZO_ScrollList_GetSelectedDataIndex(WizardsWardrobeArrangeDialogList)
-		local dataList = ZO_ScrollList_GetDataList(WizardsWardrobeArrangeDialogList)
-		
+
+		local dataList = ZO_ScrollList_GetDataList( WizardsWardrobeArrangeDialogList )
+
+		local current = dataList[ index ]
+		local above = dataList[ index - 1 ]
+
+		dataList[ index ] = above
+		dataList[ index - 1 ] = current
+
+		ZO_ScrollList_Commit( WizardsWardrobeArrangeDialogList )
+		WizardsWardrobeArrangeDialogList:GetNamedChild( "ScrollBar" ):SetHidden( false )
+	end )
+	WizardsWardrobeArrangeDialogDown:SetHandler( "OnClicked", function( self )
+		local index = ZO_ScrollList_GetSelectedDataIndex( WizardsWardrobeArrangeDialogList )
+		local dataList = ZO_ScrollList_GetDataList( WizardsWardrobeArrangeDialogList )
+
 		if not index or index == #dataList then return end
-		
-		local current = dataList[index]
-		local below = dataList[index + 1]
-		
-		dataList[index] = below
-		dataList[index + 1] = current
-		
-		ZO_ScrollList_Commit(WizardsWardrobeArrangeDialogList)
-		WizardsWardrobeArrangeDialogList:GetNamedChild("ScrollBar"):SetHidden(false)
-	end)
-	
-	local function OnRowSetup(rowControl, data, scrollList)
-		rowControl:SetFont("ZoFontGame")
-		rowControl:SetMaxLineCount(1)
-		rowControl:SetText(data.name)
-		rowControl:SetHandler("OnMouseUp", function() ZO_ScrollList_MouseClick(scrollList, rowControl) end)
+
+		local current = dataList[ index ]
+		local below = dataList[ index + 1 ]
+
+		dataList[ index ] = below
+		dataList[ index + 1 ] = current
+
+		ZO_ScrollList_Commit( WizardsWardrobeArrangeDialogList )
+		WizardsWardrobeArrangeDialogList:GetNamedChild( "ScrollBar" ):SetHidden( false )
+	end )
+
+	local function OnRowSetup( rowControl, data, scrollList )
+		rowControl:SetFont( "ZoFontGame" )
+		rowControl:SetMaxLineCount( 1 )
+		rowControl:SetText( data.name )
+		rowControl:SetHandler( "OnMouseUp", function() ZO_ScrollList_MouseClick( scrollList, rowControl ) end )
 	end
-	
-	local function OnSelection(previouslySelectedData, selectedData, reselectingDuringRebuild)
+
+	local function OnSelection( previouslySelectedData, selectedData, reselectingDuringRebuild )
 		if not selectedData then return end
 	end
-	
-	ZO_ScrollList_AddDataType(WizardsWardrobeArrangeDialogList, 1, "ZO_SelectableLabel", 30, OnRowSetup, nil, nil, nil)
-	ZO_ScrollList_EnableSelection(WizardsWardrobeArrangeDialogList, "ZO_ThinListHighlight", OnSelection)
-	ZO_ScrollList_EnableHighlight(WizardsWardrobeArrangeDialogList, "ZO_ThinListHighlight")
-	ZO_ScrollList_SetDeselectOnReselect(WizardsWardrobeArrangeDialogList, false)
-	table.insert(WWG.dialogList, WizardsWardrobeArrange)
+
+	ZO_ScrollList_AddDataType( WizardsWardrobeArrangeDialogList, 1, "ZO_SelectableLabel", 30, OnRowSetup, nil, nil, nil )
+	ZO_ScrollList_EnableSelection( WizardsWardrobeArrangeDialogList, "ZO_ThinListHighlight", OnSelection )
+	ZO_ScrollList_EnableHighlight( WizardsWardrobeArrangeDialogList, "ZO_ThinListHighlight" )
+	ZO_ScrollList_SetDeselectOnReselect( WizardsWardrobeArrangeDialogList, false )
+	table.insert( WWG.dialogList, WizardsWardrobeArrange )
 end
 
-function WWG.ShowArrangeDialog(zone, pageId)
+function WWG.ShowArrangeDialog( zone, pageId )
 	local function GetSetupList()
 		local setupList = {}
-		for entry in WW.PageIterator(zone, pageId) do
-			table.insert(setupList, {
+		for entry in WW.PageIterator( zone, pageId ) do
+			table.insert( setupList, {
 				name = entry.setup.name,
 				index = entry.index
-			})
+			} )
 		end
 		return setupList
 	end
-	
-	local function UpdateScrollList(data)
-		local dataCopy = ZO_DeepTableCopy(data)
-		local dataList = ZO_ScrollList_GetDataList(WizardsWardrobeArrangeDialogList)
-		
-		ZO_ClearNumericallyIndexedTable(dataList)
-		
-		for _, value in ipairs(dataCopy) do
-			local entry = ZO_ScrollList_CreateDataEntry(1, value)
-			table.insert(dataList, entry)
+
+	local function UpdateScrollList( data )
+		local dataCopy = ZO_DeepTableCopy( data )
+		local dataList = ZO_ScrollList_GetDataList( WizardsWardrobeArrangeDialogList )
+
+		ZO_ClearNumericallyIndexedTable( dataList )
+
+		for _, value in ipairs( dataCopy ) do
+			local entry = ZO_ScrollList_CreateDataEntry( 1, value )
+			table.insert( dataList, entry )
 		end
-		
-		ZO_ScrollList_Commit(WizardsWardrobeArrangeDialogList)
+
+		ZO_ScrollList_Commit( WizardsWardrobeArrangeDialogList )
 	end
-	
+
 	local data = GetSetupList()
-	UpdateScrollList(data)
-	
-	WizardsWardrobeArrange:SetHidden(false)
-	
-	WizardsWardrobeArrangeDialogList:GetNamedChild("ScrollBar"):SetHidden(false)
+	UpdateScrollList( data )
+
+	WizardsWardrobeArrange:SetHidden( false )
+
+	WizardsWardrobeArrangeDialogList:GetNamedChild( "ScrollBar" ):SetHidden( false )
 end
 
-function WWG.RearrangeSetups(sortTable, zone, pageId)
-	local pageCopy = ZO_DeepTableCopy(WW.setups[zone.tag][pageId])
-	for newIndex, entry in ipairs(sortTable) do
+function WWG.RearrangeSetups( sortTable, zone, pageId )
+	local pageCopy = ZO_DeepTableCopy( WW.setups[ zone.tag ][ pageId ] )
+	for newIndex, entry in ipairs( sortTable ) do
 		local oldIndex = entry.data.index
 		if newIndex ~= oldIndex then
-			WW.setups[zone.tag][pageId][newIndex] = pageCopy[oldIndex]
+			WW.setups[ zone.tag ][ pageId ][ newIndex ] = pageCopy[ oldIndex ]
 		end
 	end
-	WWG.BuildPage(zone, pageId, true)
-	WizardsWardrobeArrange:SetHidden(true)
+	WWG.BuildPage( zone, pageId, true )
+	WizardsWardrobeArrange:SetHidden( true )
 end

--- a/src/WizardsWardrobeQueue.lua
+++ b/src/WizardsWardrobeQueue.lua
@@ -3,54 +3,53 @@ local WW = WizardsWardrobe
 
 WW.queue = {}
 local WWQ = WW.queue
-WWQ.list = {first = 0, last = -1}
+WWQ.list = { first = 0, last = -1 }
 local WWL = WWQ.list
 
 function WWQ.Init()
 	WWQ.name = WW.name .. "Queue"
 	WWQ.queueRunning = false
-	EVENT_MANAGER:RegisterForEvent(WWQ.name, EVENT_PLAYER_COMBAT_STATE, WWQ.StartQueue)
-	EVENT_MANAGER:RegisterForEvent(WWQ.name, EVENT_PLAYER_REINCARNATED, WWQ.StartQueue) -- no longer ghost
-	EVENT_MANAGER:RegisterForEvent(WWQ.name, EVENT_PLAYER_ALIVE, WWQ.StartQueue) -- revive at wayshrine
+	EVENT_MANAGER:RegisterForEvent( WWQ.name, EVENT_PLAYER_COMBAT_STATE, WWQ.StartQueue )
+	EVENT_MANAGER:RegisterForEvent( WWQ.name, EVENT_PLAYER_REINCARNATED, WWQ.StartQueue ) -- no longer ghost
+	EVENT_MANAGER:RegisterForEvent( WWQ.name, EVENT_PLAYER_ALIVE, WWQ.StartQueue )     -- revive at wayshrine
 end
 
 function WWQ.Run()
 	if WWQ.queueRunning then
 		return
 	end
-	
+
 	WWQ.queueRunning = true
 	while WWQ.Size() > 0
-		and not IsUnitInCombat("player")
-		and not IsUnitDeadOrReincarnating("player") do 
-		
+		and not IsUnitInCombat( "player" )
+		and not IsUnitDeadOrReincarnating( "player" ) do
 		local task = WWQ.Pop()
 		task()
 	end
 	WWQ.queueRunning = false
 end
 
-function WWQ.Push(task, delay)
+function WWQ.Push( task, delay )
 	if delay and delay > 0 then
 		local delayedFunction = function()
-			zo_callLater(task, delay)
+			zo_callLater( task, delay )
 		end
-		WWQ.Push(delayedFunction)
+		WWQ.Push( delayedFunction )
 		return
 	end
-	
+
 	local last = WWL.last + 1
 	WWL.last = last
-	WWL[last] = task
-	
+	WWL[ last ] = task
+
 	WWQ.Run()
 end
 
 function WWQ.Pop()
 	if WWQ.Size() < 1 then return nil end
 	local first = WWL.first
-	local task = WWL[first]
-	WWL[first] = nil
+	local task = WWL[ first ]
+	WWL[ first ] = nil
 	WWL.first = first + 1
 	return task
 end
@@ -60,13 +59,13 @@ function WWQ.Size()
 end
 
 function WWQ.Reset()
-	WWL = {first = 0, last = -1}
+	WWL = { first = 0, last = -1 }
 end
 
 function WWQ.StartQueue()
-	zo_callLater(function()
-		if WWQ.Size() > 0 and not IsUnitInCombat("player") then
-			WWQ.Run()
-		end
-	end, 800)
+	zo_callLater( function()
+					  if WWQ.Size() > 0 and not IsUnitInCombat( "player" ) then
+						  WWQ.Run()
+					  end
+				  end, 800 )
 end

--- a/src/WizardsWardrobeSetup.lua
+++ b/src/WizardsWardrobeSetup.lua
@@ -2,13 +2,13 @@ WizardsWardrobe = WizardsWardrobe or {}
 local WW = WizardsWardrobe
 
 Setup = {
-	name = GetString(WW_EMPTY),
+	name = GetString( WW_EMPTY ),
 	disabled = false,
 	condition = {},
 	code = "",
 	skills = {
-		[0] = {},
-		[1] = {},
+		[ 0 ] = {},
+		[ 1 ] = {},
 	},
 	gear = {
 		mythic = nil,
@@ -17,22 +17,22 @@ Setup = {
 	food = {},
 }
 
-function Setup:New(data)
+function Setup:New( data )
 	data = data or {}
-	setmetatable(data, self)
+	setmetatable( data, self )
 	self.__index = self
 	return data
 end
 
-function Setup:FromStorage(tag, pageId, index)
+function Setup:FromStorage( tag, pageId, index )
 	local data = {
-		name = GetString(WW_EMPTY),
+		name = GetString( WW_EMPTY ),
 		disabled = false,
 		condition = {},
 		code = "",
 		skills = {
-			[0] = {},
-			[1] = {},
+			[ 0 ] = {},
+			[ 1 ] = {},
 		},
 		gear = {
 			mythic = nil,
@@ -40,38 +40,37 @@ function Setup:FromStorage(tag, pageId, index)
 		cp = {},
 		food = {},
 	}
-	if WW.setups[tag]
-		and WW.setups[tag][pageId]
-		and WW.setups[tag][pageId][index] then
-		
-		data = ZO_DeepTableCopy(WW.setups[tag][pageId][index])
+	if WW.setups[ tag ]
+		and WW.setups[ tag ][ pageId ]
+		and WW.setups[ tag ][ pageId ][ index ] then
+		data = ZO_DeepTableCopy( WW.setups[ tag ][ pageId ][ index ] )
 	end
-	setmetatable(data, self)
+	setmetatable( data, self )
 	self.__index = self
 	return data
 end
 
-function Setup:ToStorage(tag, pageId, index)
-	if not WW.setups[tag] then
-		WW.setups[tag] = {}
+function Setup:ToStorage( tag, pageId, index )
+	if not WW.setups[ tag ] then
+		WW.setups[ tag ] = {}
 	end
-	if not WW.setups[tag][pageId] then
-		WW.setups[tag][pageId] = {}
+	if not WW.setups[ tag ][ pageId ] then
+		WW.setups[ tag ][ pageId ] = {}
 	end
-	if not WW.setups[tag][pageId][index] then
-		WW.setups[tag][pageId][index] = {}
+	if not WW.setups[ tag ][ pageId ][ index ] then
+		WW.setups[ tag ][ pageId ][ index ] = {}
 	end
-	WW.setups[tag][pageId][index] = ZO_DeepTableCopy(self:GetData())
+	WW.setups[ tag ][ pageId ][ index ] = ZO_DeepTableCopy( self:GetData() )
 end
 
 function Setup:Clear()
-	self.name = GetString(WW_EMPTY)
+	self.name = GetString( WW_EMPTY )
 	self.disabled = false
 	self.condition = {}
 	self.code = ""
 	self.skills = {
-		[0] = {},
-		[1] = {},
+		[ 0 ] = {},
+		[ 1 ] = {},
 	}
 	self.gear = {
 		mythic = nil,
@@ -95,11 +94,11 @@ end
 
 function Setup:IsEmpty()
 	local i = 0
-	if next(self.skills[0]) then i = i + 1 end
-	if next(self.skills[1]) then i = i + 1 end
-	if next(self.cp) then i = i + 1 end
-	if next(self.gear) then i = i + 1 end
-	if next(self.food) then i = i + 1 end
+	if next( self.skills[ 0 ] ) then i = i + 1 end
+	if next( self.skills[ 1 ] ) then i = i + 1 end
+	if next( self.cp ) then i = i + 1 end
+	if next( self.gear ) then i = i + 1 end
+	if next( self.food ) then i = i + 1 end
 	if #self.code > 0 then i = i + 1 end
 	return i == 0
 end
@@ -108,7 +107,7 @@ function Setup:IsDisabled()
 	return self.disabled
 end
 
-function Setup:SetDisabled(disabled)
+function Setup:SetDisabled( disabled )
 	self.disabled = disabled
 end
 
@@ -116,8 +115,8 @@ function Setup:GetName()
 	return self.name
 end
 
-function Setup:SetName(name)
-	self.name = name or GetString(WW_UNNAMED)
+function Setup:SetName( name )
+	self.name = name or GetString( WW_UNNAMED )
 end
 
 function Setup:HasCondition()
@@ -131,7 +130,7 @@ function Setup:GetCondition()
 	return self.condition
 end
 
-function Setup:SetCondition(conditionTable)
+function Setup:SetCondition( conditionTable )
 	self.condition = conditionTable
 end
 
@@ -139,16 +138,16 @@ function Setup:GetCode()
 	return self.code
 end
 
-function Setup:SetCode(code)
+function Setup:SetCode( code )
 	self.code = code
 end
 
-function Setup:ExecuteCode(setup, zone, pageId, index, auto)
+function Setup:ExecuteCode( setup, zone, pageId, index, auto )
 	if not self.code then return end
-	local func = string.format("return function(setup, zone, pageId, index, auto) %s end", self.code)
-	local exec = zo_loadstring(func)
+	local func = string.format( "return function(setup, zone, pageId, index, auto) %s end", self.code )
+	local exec = zo_loadstring( func )
 	if exec then
-		exec()(setup, zone, pageId, index, auto)
+		exec()( setup, zone, pageId, index, auto )
 	end
 end
 
@@ -156,106 +155,106 @@ function Setup:GetSkills()
 	return self.skills
 end
 
-function Setup:SetSkills(skillTable)
+function Setup:SetSkills( skillTable )
 	self.skills = skillTable
 end
 
-function Setup:SetSkill(hotbar, slot, abilityId)
-	self.skills[hotbar][slot] = abilityId
+function Setup:SetSkill( hotbar, slot, abilityId )
+	self.skills[ hotbar ][ slot ] = abilityId
 end
 
-function Setup:GetHotbar(hotbarCategory)
-	return self.skills[hotbarCategory]
+function Setup:GetHotbar( hotbarCategory )
+	return self.skills[ hotbarCategory ]
 end
 
 function Setup:GetSkillsText()
-	if not next(self.skills[0]) and not next(self.skills[1]) then return GetString(WW_BUTTON_SKILLS) end
+	if not next( self.skills[ 0 ] ) and not next( self.skills[ 1 ] ) then return GetString( WW_BUTTON_SKILLS ) end
 	local skillsText = {}
-		for hotbar = 0, 1 do
-			for slot = 3, 8 do
-				local abilityId = self:GetHotbar(hotbar)[slot]
-				if abilityId and abilityId > 0 then
-					local abilityName = zo_strformat("<<C:1>>", GetAbilityName(abilityId))
-					table.insert(skillsText, abilityName)
-				end
+	for hotbar = 0, 1 do
+		for slot = 3, 8 do
+			local abilityId = self:GetHotbar( hotbar )[ slot ]
+			if abilityId and abilityId > 0 then
+				local abilityName = zo_strformat( "<<C:1>>", GetAbilityName( abilityId ) )
+				table.insert( skillsText, abilityName )
 			end
 		end
-	return table.concat(skillsText, "\n")
+	end
+	return table.concat( skillsText, "\n" )
 end
 
 function Setup:GetGear()
 	return self.gear
 end
 
-function Setup:SetGear(gearTable)
+function Setup:SetGear( gearTable )
 	self.gear = gearTable
 	WW.markers.BuildGearList()
 end
 
-function Setup:GetGearInSlot(gearSlot)
-	if self.gear[gearSlot] and self.gear[gearSlot].id ~= "0" then
-		return self.gear[gearSlot]
+function Setup:GetGearInSlot( gearSlot )
+	if self.gear[ gearSlot ] and self.gear[ gearSlot ].id ~= "0" then
+		return self.gear[ gearSlot ]
 	end
 	return nil
 end
 
 function Setup:GetMythic()
-	return self.gear.mythic, self:GetGearInSlot(self.gear.mythic)
+	return self.gear.mythic, self:GetGearInSlot( self.gear.mythic )
 end
 
-function Setup:SetMythic(gearSlot)
+function Setup:SetMythic( gearSlot )
 	self.gear.mythic = gearSlot
 end
 
 function Setup:GetGearText()
-	if not next(self.gear) then return GetString(WW_BUTTON_GEAR) end
+	if not next( self.gear ) then return GetString( WW_BUTTON_GEAR ) end
 	local gearText = {}
-	for _, gearSlot in ipairs(WW.GEARSLOTS) do
-		if self.gear[gearSlot] then
-			local link = self.gear[gearSlot].link
+	for _, gearSlot in ipairs( WW.GEARSLOTS ) do
+		if self.gear[ gearSlot ] then
+			local link = self.gear[ gearSlot ].link
 			if link and #link > 0 then
-				local itemQuality = GetItemLinkDisplayQuality(link)
-				local itemColor = GetItemQualityColor(itemQuality)
-				local itemName = LocalizeString("<<C:1>>", GetItemLinkName(link))
-				if self.gear[gearSlot].creator then
-					itemName = string.format("%s (%s)", itemName, self.gear[gearSlot].creator)
+				local itemQuality = GetItemLinkDisplayQuality( link )
+				local itemColor = GetItemQualityColor( itemQuality )
+				local itemName = LocalizeString( "<<C:1>>", GetItemLinkName( link ) )
+				if self.gear[ gearSlot ].creator then
+					itemName = string.format( "%s (%s)", itemName, self.gear[ gearSlot ].creator )
 				end
-				table.insert(gearText, itemColor:Colorize(itemName))
+				table.insert( gearText, itemColor:Colorize( itemName ) )
 			end
 		end
 	end
-	return table.concat(gearText, "\n")
+	return table.concat( gearText, "\n" )
 end
 
 function Setup:GetCP()
 	return self.cp
 end
 
-function Setup:SetCP(cpTable)
+function Setup:SetCP( cpTable )
 	self.cp = cpTable
 end
 
 function Setup:GetCPText()
-	if not next(self.cp) then return GetString(WW_BUTTON_CP) end
+	if not next( self.cp ) then return GetString( WW_BUTTON_CP ) end
 	local cpText = {}
-		for slotIndex = 1, 12 do
-			local skillId = self.cp[slotIndex]
-			if skillId then
-				local skillName = zo_strformat("<<C:1>>", GetChampionSkillName(skillId))
-				if #skillName > 0 then
-					local line = string.format("|c%s%s|r", WW.CPCOLOR[slotIndex], skillName)
-					table.insert(cpText, line)
-				end
+	for slotIndex = 1, 12 do
+		local skillId = self.cp[ slotIndex ]
+		if skillId then
+			local skillName = zo_strformat( "<<C:1>>", GetChampionSkillName( skillId ) )
+			if #skillName > 0 then
+				local line = string.format( "|c%s%s|r", WW.CPCOLOR[ slotIndex ], skillName )
+				table.insert( cpText, line )
 			end
 		end
-	return table.concat(cpText, "\n")
+	end
+	return table.concat( cpText, "\n" )
 end
 
 function Setup:GetFood()
 	return self.food
 end
 
-function Setup:SetFood(foodTable)
+function Setup:SetFood( foodTable )
 	self.food = foodTable
 end
 
@@ -264,12 +263,11 @@ function WW.MigrateSkills()
 	local migratedCounter = 0
 	for entry in WW.SetupIterator() do
 		local setup = entry.setup
-		if setup.skills and type(setup.skills[0][3]) == "table" then
+		if setup.skills and type( setup.skills[ 0 ][ 3 ] ) == "table" then
 			for hotbar = 0, 1 do
 				for slot = 3, 8 do
-					local abilityId = setup.skills[hotbar][slot].id
-					setup.skills[hotbar][slot] = tonumber(abilityId)
-					
+					local abilityId = setup.skills[ hotbar ][ slot ].id
+					setup.skills[ hotbar ][ slot ] = tonumber( abilityId )
 				end
 			end
 			migratedCounter = migratedCounter + 1
@@ -277,5 +275,5 @@ function WW.MigrateSkills()
 		setupCounter = setupCounter + 1
 	end
 	local messagePattern = "Looped through %d setups and migrated %d of them."
-	WW.Log(messagePattern, WW.LOGTYPES.INFO, "FFFFFF", setupCounter, migratedCounter)
+	WW.Log( messagePattern, WW.LOGTYPES.INFO, "FFFFFF", setupCounter, migratedCounter )
 end

--- a/src/WizardsWardrobeSetupValidation.lua
+++ b/src/WizardsWardrobeSetupValidation.lua
@@ -1,0 +1,402 @@
+WizardsWardrobe               = WizardsWardrobe or {}
+local WW                      = WizardsWardrobe
+WW.validation                 = WW.validation or {}
+local WWV                     = WW.validation
+WW.name                       = "WizardsWardrobe"
+WW.simpleName                 = "Wizard's Wardrobe"
+WW.displayName                =
+"|c18bed8W|c26c2d1i|c35c6c9z|c43cac2a|c52cebar|c60d1b3d|c6fd5ab'|c7dd9a4s|c8cdd9d |c9ae195W|ca8e58ea|cb7e986r|cc5ed7fd|cd4f077r|ce2f470o|cf1f868b|cfffc61e|r"
+
+local logger                  = LibDebugLogger( WW.name )
+local async                   = LibAsync
+local validationTask          = async:Create( WW.name .. "Validation" )
+local setupName               = ""
+local validationDelay         = 1500
+local WORKAROUND_INITIAL_CALL = 0
+local WORKAROUND_ONE          = 1
+local WORKAROUND_TWO          = 2
+local WORKAROUND_THREE        = 3
+local WORKAROUND_FOUR         = 4
+
+
+
+function WWV.CompareItemLinks( linkEquipped, linkSaved, uniqueIdEquipped, uniqueIdSaved )
+    local traitEquipped             = GetItemLinkTraitInfo( linkEquipped )
+    local weaponTypeEquipped        = GetItemLinkWeaponType( linkEquipped )
+    local weaponTypeSaved           = GetItemLinkWeaponType( linkSaved )
+    local traitSaved                = GetItemLinkTraitInfo( linkSaved )
+    local _, _, _, _, setIdEquipped = GetItemLinkSetInfo( linkEquipped )
+    local _, _, _, _, setIdSaved    = GetItemLinkSetInfo( linkSaved )
+
+    if WW.settings.comparisonDepth == 1 then -- easy
+        if traitEquipped ~= traitSaved or weaponTypeEquipped ~= weaponTypeSaved or setIdEquipped ~= setIdSaved then
+            return false
+        end
+        return true
+    end
+    local qualityEquipped = GetItemLinkDisplayQuality( linkEquipped )
+    local enchantEquipped = GetItemLinkEnchantInfo( linkEquipped )
+    local qualitySaved = GetItemLinkDisplayQuality( linkSaved )
+    local enchantSaved = GetItemLinkEnchantInfo( linkSaved )
+
+    if WW.settings.comparisonDepth == 2 then -- detailed
+        if (traitEquipped ~= traitSaved) or (weaponTypeEquipped ~= weaponTypeSaved) or (setIdEquipped ~= setIdSaved) or (qualityEquipped ~= qualitySaved) then
+            return false
+        end
+        return true
+    end
+
+
+    if WW.settings.comparisonDepth == 3 then -- thorough
+        if (traitEquipped ~= traitSaved) or (weaponTypeEquipped ~= weaponTypeSaved) or (setIdEquipped ~= setIdSaved) or (qualityEquipped ~= qualitySaved) or (enchantEquipped ~= enchantSaved) then
+            return false
+        end
+        return true
+    end
+
+    if WW.settings.comparisonDepth == 4 then -- strict
+        if uniqueIdEquipped ~= uniqueIdSaved then
+            return false
+        end
+        return true
+    end
+end
+
+--TODO: untangle this mess. should prob make a metamethod to compare setups instead of this
+function WWV.DidSetupSwapCorrectly( workAround )
+    local zone        = WW.selection.zone
+    local tag         = zone.tag
+    local pageId      = WW.selection.pageId
+    local index       = WW.currentIndex
+    local setupTable  = Setup:FromStorage( tag, pageId, index )
+    local check       = nil
+    local t           = {}
+    local timeStamp   = GetTimeStamp()
+    local inCombat    = IsUnitInCombat( "player" )
+    local worldName   = GetWorldName()
+    local characterId = GetCurrentCharacterId()
+    local pageName    = zone.name
+    local zoneName    = GetPlayerActiveZoneName()
+    local isBlocking  = IsBlockActive()
+    local subZone     = GetPlayerActiveSubzoneName()
+    local failedT     = {}
+    local db          = WW.settings
+    local key         = GetWorldName() .. GetDisplayName() .. GetCurrentCharacterId() .. os.date( "%Y%m%d%H" ) .. index
+    if not db.failedSwapLog then db.failedSwapLog = {} end
+    db = db.failedSwapLog
+
+    if setupTable and setupTable.gear then
+        setupName = setupTable.name
+        for _, equipSlot in pairs( WW.GEARSLOTS ) do
+            if setupTable.gear[ equipSlot ] then
+                local equippedLink = GetItemLink( BAG_WORN, equipSlot, LINK_STYLE_DEFAULT )
+                local savedLink    = setupTable.gear[ equipSlot ].link
+                local equippedUId  = Id64ToString( GetItemUniqueId( BAG_WORN, equipSlot ) )
+                local savedUId     = setupTable.gear[ equipSlot ].id
+                local success      = nil
+                if WWV.CompareItemLinks( equippedLink, savedLink, equippedUId, savedUId ) then
+                    success = true
+                else
+                    success = false
+                    failedT[ # failedT + 1 ] = GetString( "SI_EQUIPSLOT", equipSlot )
+                    logger:Info( "Equipped %s // saved %s", equippedLink, savedLink )
+                    if workAround > 0 then
+                        if not db[ equipSlot ] then db[ equipSlot ] = {} end
+                        --No need to log for each workaround, just log the last
+                        EVENT_MANAGER:RegisterForUpdate( WW.name .. "Throttle" .. equipSlot, 5000, function()
+                            if not db[ equipSlot ][ key ] then db[ equipSlot ][ key ] = {} end
+                            db[ equipSlot ][ key ] = {
+                                timeStamp    = timeStamp,
+                                inCombat     = inCombat,
+                                worldName    = worldName,
+                                characterId  = characterId,
+                                pageName     = pageName,
+                                zone         = zoneName,
+                                subzone      = subZone,
+                                pageId       = pageId,
+                                setupName    = setupName,
+                                equippedLink = equippedLink,
+                                savedLink    = savedLink,
+                                settings     = {
+                                    gear   = WW.settings.auto.gear,
+                                    skills = WW.settings.auto.skills,
+                                    cp     = WW.settings.auto.cp,
+                                    food   = WW.settings.auto.food,
+                                },
+                                workAround   = workAround,
+                                isBlocking   = isBlocking
+
+                            }
+                            EVENT_MANAGER:UnregisterForUpdate( WW.name .. "Throttle" .. equipSlot )
+                        end )
+                    end
+                end
+                t[ equipSlot ] = success
+            end
+
+            for eqSlot, success in pairs( t ) do
+                if not success then
+                    check = false
+                    break
+                else
+                    check = true
+                end
+            end
+        end
+    end
+    return check, failedT
+end
+
+local function failureFunction()
+    validationTask:Cancel()
+    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "Throttle" )
+    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "Throttle2" )
+    EVENT_MANAGER:UnregisterForEvent( WW.name, EVENT_INVENTORY_SINGLE_SLOT_UPDATE )
+    EVENT_MANAGER:UnregisterForEvent( WW.name .. "workaroundOne", EVENT_INVENTORY_SINGLE_SLOT_UPDATE )
+    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "ThrottleWorkaroundOne" )
+    EVENT_MANAGER:UnregisterForEvent( WW.name .. "workaroundTwo", EVENT_INVENTORY_SINGLE_SLOT_UPDATE )
+    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "ThrottleWorkaroundTwo" )
+    EVENT_MANAGER:UnregisterForEvent( WW.name .. "workaroundThree", EVENT_INVENTORY_SINGLE_SLOT_UPDATE )
+    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "ThrottleWorkaroundThree" )
+    EVENT_MANAGER:UnregisterForEvent( WW.name .. "workaroundFour", EVENT_INVENTORY_SINGLE_SLOT_UPDATE )
+    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "ThrottleWorkaroundTFour" )
+    WW.Log( GetString( WW_MSG_SWAP_FIX_FAIL ), WW.LOGTYPES.ERROR )
+end
+local function successFunction()
+    -- Cancel everything in case swap worked out sooner than expected to avoid having situations where some function gets called endlessly
+    validationTask:Cancel()
+    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "Throttle" )
+    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "Throttle2" )
+    EVENT_MANAGER:UnregisterForEvent( WW.name, EVENT_INVENTORY_SINGLE_SLOT_UPDATE )
+    EVENT_MANAGER:UnregisterForEvent( WW.name .. "workaroundOne", EVENT_INVENTORY_SINGLE_SLOT_UPDATE )
+    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "ThrottleWorkaroundOne" )
+    EVENT_MANAGER:UnregisterForEvent( WW.name .. "workaroundTwo", EVENT_INVENTORY_SINGLE_SLOT_UPDATE )
+    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "ThrottleWorkaroundTwo" )
+    EVENT_MANAGER:UnregisterForEvent( WW.name .. "workaroundThree", EVENT_INVENTORY_SINGLE_SLOT_UPDATE )
+    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "ThrottleWorkaroundThree" )
+    EVENT_MANAGER:UnregisterForEvent( WW.name .. "workaroundFour", EVENT_INVENTORY_SINGLE_SLOT_UPDATE )
+    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "ThrottleWorkaroundTFour" )
+    WW.Log( GetString( WW_MSG_SWAPSUCCESS ), WW.LOGTYPES.NORMAL )
+    local middleText = string.format( "|c%s%s|r", WW.LOGTYPES.NORMAL, setupName )
+    WizardsWardrobePanelBottomLabel:SetText( middleText )
+end
+
+
+--[[ Last ditch effort, I have in all my testing never seen that anything other than weapons got stuck.
+ So this should never happen, we still have it in case something odd is happening ]]
+
+local function workaroundFour()
+    logger:Info( "workaround four got called" )
+    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "ThrottleWorkaroundThree" )
+    EVENT_MANAGER:UnregisterForEvent( WW.name .. "workaroundThree", EVENT_INVENTORY_SINGLE_SLOT_UPDATE )
+
+    -- Redundancy in case everything is stuck and no event triggers. This will hopefully always be unregistered before it actually gets called
+    EVENT_MANAGER:RegisterForUpdate( WW.name .. "Throttle2", 5000,
+                                     function()
+                                         failureFunction() -- If all swaps have failed.
+                                     end )
+
+    if not WWV.DidSetupSwapCorrectly( WORKAROUND_FOUR ) then
+        validationTask:Call( function()
+            WW.Undress()
+        end ):WaitUntil( function() -- Wait until every worn item is in the bag
+            local isNotEmpty = nil
+            for _, equipSlot in pairs( WW.GEARSLOTS ) do
+                if Id64ToString( GetItemUniqueId( BAG_WORN, equipSlot ) ) ~= "0" then
+                    isNotEmpty = true
+                elseif Id64ToString( GetItemUniqueId( BAG_WORN, equipSlot ) ) == "0" and not isNotEmpty then
+                    isNotEmpty = false
+                end
+            end
+            return not isNotEmpty
+        end ):Then( function()
+            WW.LoadSetupAdjacent( 0 ) -- reload current setup
+        end ):Call( function()
+            EVENT_MANAGER:RegisterForEvent( WW.name .. "workaroundThree", EVENT_INVENTORY_SINGLE_SLOT_UPDATE, function()
+                EVENT_MANAGER:RegisterForUpdate( WW.name .. "Throttle", validationDelay / 2, function()
+                    if WWV.DidSetupSwapCorrectly( WORKAROUND_FOUR ) then
+                        successFunction()
+                    else
+                        failureFunction()
+                    end
+                    EVENT_MANAGER:UnregisterForEvent( WW.name .. "workaroundThree", EVENT_INVENTORY_SINGLE_SLOT_UPDATE )
+                    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "Throttle" )
+                end )
+            end )
+        end )
+    else
+        successFunction()
+    end
+end
+
+-- Unequip weapons and reload setup
+local function workaroundThree()
+    logger:Info( "workaround three got called" )
+    local t = {
+        EQUIP_SLOT_MAIN_HAND,
+        EQUIP_SLOT_OFF_HAND,
+        EQUIP_SLOT_BACKUP_MAIN,
+        EQUIP_SLOT_BACKUP_OFF
+    }
+
+
+    Setup:GetData()
+    local moveTask = async:Create( WW.name .. "Move" )
+    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "ThrottleWorkaroundTwo" )
+    EVENT_MANAGER:UnregisterForEvent( WW.name .. "workaroundTwo", EVENT_INVENTORY_SINGLE_SLOT_UPDATE )
+    EVENT_MANAGER:RegisterForEvent( WW.name .. "workaroundThree", EVENT_INVENTORY_SINGLE_SLOT_UPDATE,
+                                    function()
+                                        moveTask:Resume() -- continue loop
+                                        EVENT_MANAGER:RegisterForUpdate( WW.name .. "ThrottleWorkaroundThree",
+                                                                         validationDelay / 2,
+                                                                         function()
+                                                                             workaroundFour()
+                                                                         end )
+                                    end )
+    EVENT_MANAGER:AddFilterForEvent( WW.name .. "workaroundThree", EVENT_INVENTORY_SINGLE_SLOT_UPDATE,
+                                     REGISTER_FILTER_BAG_ID,
+                                     BAG_WORN )
+
+    EVENT_MANAGER:AddFilterForEvent( WW.name .. "workaroundThree", EVENT_INVENTORY_SINGLE_SLOT_UPDATE,
+                                     REGISTER_FILTER_INVENTORY_UPDATE_REASON,
+                                     INVENTORY_UPDATE_REASON_DEFAULT )
+
+
+
+    moveTask:Call( function()
+        if not WWV.DidSetupSwapCorrectly( WORKAROUND_THREE ) then
+            moveTask:For( 1, #t ):Do( function( index )
+                local emptySlot = FindFirstEmptySlotInBag( BAG_BACKPACK )
+                local equipSlot = t[ index ]
+                local weaponType = GetItemWeaponType( BAG_WORN, equipSlot )
+                local link = GetItemLink( BAG_WORN, equipSlot, LINK_STYLE_DEFAULT )
+
+                if weaponType ~= WEAPONTYPE_NONE then
+                    CallSecureProtected( "RequestMoveItem", BAG_WORN, equipSlot, BAG_BACKPACK, emptySlot, 1 )
+                    moveTask:Suspend() -- Suspend loop until item has actually moved
+                end
+            end ):Then( function() WW.LoadSetupAdjacent( 0 ) end )
+        else
+            successFunction()
+        end
+    end )
+    EVENT_MANAGER:RegisterForUpdate( WW.name .. "ThrottleWorkaroundThree", validationDelay, workaroundFour ) -- If no item moved, move on to workaround four
+end
+
+-- Reload setup
+local function workaroundTwo()
+    logger:Info( "workaroundTwo got called" )
+    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "ThrottleWorkaroundOne" )
+    EVENT_MANAGER:UnregisterForEvent( WW.name .. "workaroundOne", EVENT_INVENTORY_SINGLE_SLOT_UPDATE )
+    validationTask:Call( function()
+        EVENT_MANAGER:RegisterForEvent( WW.name .. "workaroundTwo", EVENT_INVENTORY_SINGLE_SLOT_UPDATE, function()
+            if WWV.DidSetupSwapCorrectly( WORKAROUND_TWO ) then
+                successFunction()
+            else
+                EVENT_MANAGER:RegisterForUpdate( WW.name .. "ThrottleWorkaroundTwo", validationDelay / 2, workaroundThree )
+            end
+        end )
+        EVENT_MANAGER:AddFilterForEvent( WW.name .. "workaroundTwo", EVENT_INVENTORY_SINGLE_SLOT_UPDATE,
+                                         REGISTER_FILTER_BAG_ID,
+                                         BAG_WORN )
+
+        EVENT_MANAGER:AddFilterForEvent( WW.name .. "workaroundTwo", EVENT_INVENTORY_SINGLE_SLOT_UPDATE,
+                                         REGISTER_FILTER_INVENTORY_UPDATE_REASON,
+                                         INVENTORY_UPDATE_REASON_DEFAULT )
+        if not WWV.DidSetupSwapCorrectly( WORKAROUND_TWO ) then
+            WW.LoadSetupAdjacent( 0 )
+        else
+            successFunction()
+        end
+        EVENT_MANAGER:RegisterForUpdate( WW.name .. "ThrottleWorkaroundTwo", validationDelay, workaroundThree ) -- wait for the gear swap event, if it doesnt happen then try workaround three
+    end )
+end
+
+-- Sheathe weapons and see if it fixes itself
+local function workaroundOne()
+    validationDelay = WW.settings.validationDelay
+    logger:Info( "workaround one got called" )
+    EVENT_MANAGER:RegisterForEvent( WW.name .. "workaroundOne", EVENT_INVENTORY_SINGLE_SLOT_UPDATE, function()
+        if WWV.DidSetupSwapCorrectly( WORKAROUND_ONE ) then
+            successFunction()
+        else
+            EVENT_MANAGER:RegisterForUpdate( WW.name .. "ThrottleWorkaroundOne", validationDelay / 2, workaroundTwo ) -- throttle to call workaround after the last event
+        end
+    end )
+    EVENT_MANAGER:AddFilterForEvent( WW.name .. "workaroundOne", EVENT_INVENTORY_SINGLE_SLOT_UPDATE,
+                                     REGISTER_FILTER_BAG_ID, BAG_WORN )
+
+    EVENT_MANAGER:AddFilterForEvent( WW.name .. "workaroundOne", EVENT_INVENTORY_SINGLE_SLOT_UPDATE,
+                                     REGISTER_FILTER_INVENTORY_UPDATE_REASON,
+                                     INVENTORY_UPDATE_REASON_DEFAULT )
+    validationTask:Call( function()
+        if not WWV.DidSetupSwapCorrectly( WORKAROUND_ONE ) then
+            if not ArePlayerWeaponsSheathed() then
+                TogglePlayerWield()
+            end
+            EVENT_MANAGER:RegisterForUpdate( WW.name .. "ThrottleWorkaroundOne", validationDelay, workaroundTwo ) -- we wait for the gear swap event, if it does not happen we try workaround two
+        else
+            successFunction()
+        end
+    end )
+end
+-- Make function accessible via keybind
+WWV.WorkAroundOne = workaroundOne
+
+local function handleSettings()
+    logger:Info( "handle settings has been called" )
+
+    EVENT_MANAGER:UnregisterForUpdate( WW.name .. "Throttle" )
+    EVENT_MANAGER:UnregisterForEvent( WW.name, EVENT_INVENTORY_SINGLE_SLOT_UPDATE )
+
+    validationTask:Call( function()
+        local success, failedT = WWV.DidSetupSwapCorrectly( WORKAROUND_INITIAL_CALL )
+
+        local failedSlotNames = table.concat( failedT, ", " )
+        if success then
+            successFunction()
+        else
+            -- Warn user regardless of the setting
+            local middleText = string.format( "|c%s%s|r", WW.LOGTYPES.ERROR, setupName )
+            WizardsWardrobePanelBottomLabel:SetText( middleText )
+            if WW.settings.fixGearSwap then
+                WW.Log( GetString( WW_MSG_SWAPFAIL ), WW.LOGTYPES.ERROR, "FFFFFF", failedSlotNames )
+                if IsUnitInCombat( "player" ) then
+                    validationTask:WaitUntil( function() return not IsUnitInCombat( "player" ) end ):Then( workaroundOne )
+                else
+                    validationTask:Call( workaroundOne )
+                end
+            else
+                WW.Log( GetString( WW_MSG_SWAPFAIL_DISABLED ), WW.LOGTYPES.ERROR, "FFFFFF", failedSlotNames )
+            end
+        end
+    end )
+end
+-- Function gets called once on setup swap
+function WWV.SetupFailWorkaround()
+    validationDelay = WW.settings.validationDelay
+    local function throttle()
+        -- throttle continously while swapping takes place until its done, so we don't have to call the workaround for every piece of gear we swap
+        EVENT_MANAGER:RegisterForUpdate( WW.name .. "Throttle", validationDelay, handleSettings )
+    end
+
+    EVENT_MANAGER:RegisterForEvent( WW.name, EVENT_INVENTORY_SINGLE_SLOT_UPDATE, throttle )
+    EVENT_MANAGER:AddFilterForEvent( WW.name, EVENT_INVENTORY_SINGLE_SLOT_UPDATE,
+                                     REGISTER_FILTER_BAG_ID, BAG_WORN )
+
+    EVENT_MANAGER:AddFilterForEvent( WW.name, EVENT_INVENTORY_SINGLE_SLOT_UPDATE,
+                                     REGISTER_FILTER_INVENTORY_UPDATE_REASON,
+                                     INVENTORY_UPDATE_REASON_DEFAULT )
+end
+
+-- Suspend all tasks when in combat and resume once we are out
+local function combatFunction( _, inCombat )
+    if inCombat then
+        validationTask:Suspend()
+    else
+        validationTask:Resume()
+    end
+end
+
+
+EVENT_MANAGER:RegisterForEvent( WW.name, EVENT_PLAYER_COMBAT_STATE, function( _, inCombat ) combatFunction( _, inCombat ) end )

--- a/src/WizardsWardrobeUtils.lua
+++ b/src/WizardsWardrobeUtils.lua
@@ -4,32 +4,31 @@ local WW = WizardsWardrobe
 WW.gui = WW.gui or {}
 local WWG = WW.gui
 
-function WW.GetSelectedPage(zone)
-	if WW.pages[zone.tag] and WW.pages[zone.tag][0] then
-		return WW.pages[zone.tag][0].selected 
+function WW.GetSelectedPage( zone )
+	if WW.pages[ zone.tag ] and WW.pages[ zone.tag ][ 0 ] then
+		return WW.pages[ zone.tag ][ 0 ].selected
 	end
 	return nil
 end
 
-function WW.GetBossName(zone, index)
+function WW.GetBossName( zone, index )
 	if zone.bosses
-		and zone.bosses[index]
-		and zone.bosses[index].name
-		and zone.bosses[index].name ~= GetString(WW_EMPTY) then
-		
-		return zone.bosses[index].displayName or zone.bosses[index].name
+		and zone.bosses[ index ]
+		and zone.bosses[ index ].name
+		and zone.bosses[ index ].name ~= GetString( WW_EMPTY ) then
+		return zone.bosses[ index ].displayName or zone.bosses[ index ].name
 	end
 	return nil
 end
 
-function WW.ChangeItemLinkStyle(itemLink, linkStyle)
-	return string.format("%s%d%s", itemLink:sub(1, 2), linkStyle, itemLink:sub(4))
+function WW.ChangeItemLinkStyle( itemLink, linkStyle )
+	return string.format( "%s%d%s", itemLink:sub( 1, 2 ), linkStyle, itemLink:sub( 4 ) )
 end
 
-function WW.CompareCP(setup)
+function WW.CompareCP( setup )
 	for slotIndex = 1, 12 do
-		local savedSkillId = setup:GetCP()[slotIndex]
-		local selectedSkilId = GetSlotBoundId(slotIndex, HOTBAR_CATEGORY_CHAMPION)
+		local savedSkillId = setup:GetCP()[ slotIndex ]
+		local selectedSkilId = GetSlotBoundId( slotIndex, HOTBAR_CATEGORY_CHAMPION )
 		if not savedSkillId or savedSkillId ~= selectedSkilId then
 			return false
 		end
@@ -37,20 +36,20 @@ function WW.CompareCP(setup)
 	return true
 end
 
-function WW.CheckGear(zone, pageId)
+function WW.CheckGear( zone, pageId )
 	local missingTable = {}
 	local inventoryList = WW.GetItemLocation()
-	for entry in WW.PageIterator(zone, pageId) do
-		local setup = Setup:FromStorage(zone.tag, pageId, entry.index)
-		for _, gearSlot in ipairs(WW.GEARSLOTS) do
+	for entry in WW.PageIterator( zone, pageId ) do
+		local setup = Setup:FromStorage( zone.tag, pageId, entry.index )
+		for _, gearSlot in ipairs( WW.GEARSLOTS ) do
 			if gearSlot ~= EQUIP_SLOT_POISON and gearSlot ~= EQUIP_SLOT_BACKUP_POISON then
-				local gear = setup:GetGearInSlot(gearSlot)
+				local gear = setup:GetGearInSlot( gearSlot )
 				if gear and gear.id ~= "0" then
-					if not inventoryList[gear.id] then
-						table.insert(missingTable, gear.link)
-						
+					if not inventoryList[ gear.id ] then
+						table.insert( missingTable, gear.link )
+
 						-- sorts out duplicates
-						inventoryList[gear.id] = 0
+						inventoryList[ gear.id ] = 0
 					end
 				end
 			end
@@ -61,10 +60,10 @@ end
 
 function WW.GetItemLocation()
 	local inventoryList = {}
-	for _, bag in ipairs({BAG_WORN, BAG_BACKPACK}) do
-		for slot = 0, GetBagSize(bag) do
-			local lookupId = Id64ToString(GetItemUniqueId(bag, slot))
-			inventoryList[lookupId] = {
+	for _, bag in ipairs( { BAG_WORN, BAG_BACKPACK } ) do
+		for slot = 0, GetBagSize( bag ) do
+			local lookupId = Id64ToString( GetItemUniqueId( bag, slot ) )
+			inventoryList[ lookupId ] = {
 				bag = bag,
 				slot = slot,
 			}
@@ -73,8 +72,8 @@ function WW.GetItemLocation()
 	return inventoryList
 end
 
-function WW.IsMythic(bag, slot)
-	local _, _, _, _, _, _, _, _, itemType = GetItemInfo(bag, slot)
+function WW.IsMythic( bag, slot )
+	local _, _, _, _, _, _, _, _, itemType = GetItemInfo( bag, slot )
 	if itemType == 6 then
 		return true
 	end
@@ -82,16 +81,16 @@ function WW.IsMythic(bag, slot)
 end
 
 function WW.IsWipe()
-	if not IsUnitGrouped("player") then
-		if IsUnitDeadOrReincarnating("player") then
+	if not IsUnitGrouped( "player" ) then
+		if IsUnitDeadOrReincarnating( "player" ) then
 			return true
 		end
 		return false
 	end
 	for i = 1, GetGroupSize() do
-		local groupTag = GetGroupUnitTagByIndex(i)
-		if IsUnitOnline(groupTag) then
-			if not IsUnitDeadOrReincarnating(groupTag) then
+		local groupTag = GetGroupUnitTagByIndex( i )
+		if IsUnitOnline( groupTag ) then
+			if not IsUnitDeadOrReincarnating( groupTag ) then
 				return false
 			end
 		end
@@ -99,39 +98,48 @@ function WW.IsWipe()
 	return true
 end
 
-function WW.Log(logMessage, logType, formatColor, ...)
-	if WW.settings.printMessages == "chat" or WW.settings.printMessages == "alert" then
+function WW.Log( logMessage, logType, formatColor, ... )
+	if WW.settings.printMessages == "chat" or WW.settings.printMessages == "alert" or WW.settings.printMessages == "announcement" then
 		if not logType then logType = WW.LOGTYPES.NORMAL end
 		if not formatColor then formatColor = "FFFFFF" end
-		logMessage = string.format(logMessage, ...)
-		logMessage = string.gsub(logMessage, "%[", "|c" .. formatColor .. "[")
-		logMessage = string.gsub(logMessage, "%]", "]|c" .. logType)
-		logMessage = string.format("|c18bed8[|c65d3b0W|cb2e789W|cfffc61]|r|c%s %s|r", logType, logMessage)
-		
+		logMessage = string.format( logMessage, ... )
+		logMessage = string.gsub( logMessage, "%[", "|c" .. formatColor .. "[" )
+		logMessage = string.gsub( logMessage, "%]", "]|c" .. logType )
+		logMessage = string.format( "|c18bed8[|c65d3b0W|cb2e789W|cfffc61]|r|c%s %s|r", logType, logMessage )
+
 		if WW.settings.printMessages == "alert" then
-			ZO_Alert(UI_ALERT_CATEGORY_ALERT, nil, logMessage)
+			ZO_Alert( UI_ALERT_CATEGORY_ALERT, nil, logMessage )
+		elseif WW.settings.printMessages == "announcement" then
+			local sound = SOUNDS.NONE
+			if logType == WW.LOGTYPES.ERROR then
+				sound = SOUNDS.GENERAL_ALERT_ERROR
+			end
+			local messageParams = CENTER_SCREEN_ANNOUNCE:CreateMessageParams( CSA_CATEGORY_MAJOR_TEXT,
+																			  sound )
+			messageParams:SetText( logMessage )
+			messageParams:SetCSAType( CENTER_SCREEN_ANNOUNCE_TYPE_BATTLEGROUND_NEARING_VICTORY )
+			CENTER_SCREEN_ANNOUNCE:AddMessageWithParams( messageParams )
 		else
-			CHAT_ROUTER:AddSystemMessage(logMessage)
+			CHAT_ROUTER:AddSystemMessage( logMessage )
 		end
 	end
 end
 
-
-function WW.GetTableLength(givenTable)
+function WW.GetTableLength( givenTable )
 	local count = 0
-	for _ in pairs(givenTable) do
+	for _ in pairs( givenTable ) do
 		count = count + 1
 	end
 	return count
 end
 
 -- food
-function WW.FindFood(foodChoice)
+function WW.FindFood( foodChoice )
 	if not foodChoice then return nil end
 	local consumables = WW.GetConsumableItems()
-	for _, itemId in ipairs(foodChoice) do
-		if consumables[itemId] then
-			return consumables[itemId]
+	for _, itemId in ipairs( foodChoice ) do
+		if consumables[ itemId ] then
+			return consumables[ itemId ]
 		end
 	end
 	return nil
@@ -139,21 +147,21 @@ end
 
 function WW.GetConsumableItems()
 	local itemList = {}
-	for slotIndex = 0, GetBagSize(BAG_BACKPACK) do
-		local itemType = GetItemType(BAG_BACKPACK, slotIndex)
+	for slotIndex = 0, GetBagSize( BAG_BACKPACK ) do
+		local itemType = GetItemType( BAG_BACKPACK, slotIndex )
 		if itemType == ITEMTYPE_DRINK or itemType == ITEMTYPE_FOOD then
-			local itemLink = GetItemLink(BAG_BACKPACK, slotIndex, LINK_STYLE_DEFAULT)
-			local itemId = GetItemLinkItemId(itemLink)
-			itemList[itemId] = slotIndex
+			local itemLink = GetItemLink( BAG_BACKPACK, slotIndex, LINK_STYLE_DEFAULT )
+			local itemId = GetItemLinkItemId( itemLink )
+			itemList[ itemId ] = slotIndex
 		end
 	end
 	return itemList
 end
 
-function WW.HasFoodIdRunning(itemId)
-	for i = 1, GetNumBuffs("player") do
-		local abilityId = select(11, GetUnitBuffInfo("player", i))
-		if WW.BUFFFOOD[itemId] == abilityId then
+function WW.HasFoodIdRunning( itemId )
+	for i = 1, GetNumBuffs( "player" ) do
+		local abilityId = select( 11, GetUnitBuffInfo( "player", i ) )
+		if WW.BUFFFOOD[ itemId ] == abilityId then
 			return abilityId
 		end
 	end
@@ -161,9 +169,9 @@ function WW.HasFoodIdRunning(itemId)
 end
 
 function WW.HasFoodRunning()
-	for i = 1, GetNumBuffs("player") do
-		local abilityId = select(11, GetUnitBuffInfo("player", i))
-		if WW.lookupBuffFood[abilityId] then
+	for i = 1, GetNumBuffs( "player" ) do
+		local abilityId = select( 11, GetUnitBuffInfo( "player", i ) )
+		if WW.lookupBuffFood[ abilityId ] then
 			return abilityId
 		end
 	end
@@ -171,68 +179,67 @@ function WW.HasFoodRunning()
 end
 
 -- gui
-function WWG.HidePage(hidden)
-	if WWG.zones[WW.selection.zone.tag]
-		and WWG.zones[WW.selection.zone.tag].scrollContainer then
-		
-		WWG.zones[WW.selection.zone.tag].scrollContainer:SetHidden(hidden)
+function WWG.HidePage( hidden )
+	if WWG.zones[ WW.selection.zone.tag ]
+		and WWG.zones[ WW.selection.zone.tag ].scrollContainer then
+		WWG.zones[ WW.selection.zone.tag ].scrollContainer:SetHidden( hidden )
 	end
 end
 
-function WWG.SetSetupDisabled(zone, pageId, index, disabled)
-	local setup = Setup:FromStorage(zone.tag, pageId, index)
-	setup:SetDisabled(disabled)
-	setup:ToStorage(zone.tag, pageId, index)
-	WWG.RefreshSetup(zone, pageId, index)
+function WWG.SetSetupDisabled( zone, pageId, index, disabled )
+	local setup = Setup:FromStorage( zone.tag, pageId, index )
+	setup:SetDisabled( disabled )
+	setup:ToStorage( zone.tag, pageId, index )
+	WWG.RefreshSetup( zone, pageId, index )
 end
 
 function WWG.GetSortedZoneList()
 	local zoneList = {}
-	for _, zone in pairs(WW.zones) do
-		table.insert(zoneList, zone)
+	for _, zone in pairs( WW.zones ) do
+		table.insert( zoneList, zone )
 	end
-	table.sort(zoneList, function(a, b) return a.priority < b.priority end)
+	table.sort( zoneList, function( a, b ) return a.priority < b.priority end )
 	return zoneList
 end
 
-function WWG.GearLinkTableToString(gearLinkTable)
+function WWG.GearLinkTableToString( gearLinkTable )
 	local gearText = {}
-	for _, gear in ipairs(gearLinkTable) do
-		local itemQuality = GetItemLinkDisplayQuality(gear)
-		local itemColor = GetItemQualityColor(itemQuality)
-		local itemName = LocalizeString("<<C:1>>", GetItemLinkName(gear))
-		table.insert(gearText, itemColor:Colorize(itemName))
+	for _, gear in ipairs( gearLinkTable ) do
+		local itemQuality = GetItemLinkDisplayQuality( gear )
+		local itemColor = GetItemQualityColor( itemQuality )
+		local itemName = LocalizeString( "<<C:1>>", GetItemLinkName( gear ) )
+		table.insert( gearText, itemColor:Colorize( itemName ) )
 	end
-	return table.concat(gearText, "\n")
+	return table.concat( gearText, "\n" )
 end
 
-function WWG.SetTooltip(control, align, text)
-	control:SetMouseEnabled(true)
-	control:SetHandler("OnMouseEnter", function(self)
+function WWG.SetTooltip( control, align, text )
+	control:SetMouseEnabled( true )
+	control:SetHandler( "OnMouseEnter", function( self )
 		if text and text ~= "" then
-			ZO_Tooltips_ShowTextTooltip(self, align, tostring(text))
+			ZO_Tooltips_ShowTextTooltip( self, align, tostring( text ) )
 		end
-	end)
-	control:SetHandler("OnMouseExit", function(self)
+	end )
+	control:SetHandler( "OnMouseExit", function( self )
 		ZO_Tooltips_HideTextTooltip()
-	end)
+	end )
 end
 
-function WWG.ShowConfirmationDialog(name, dialogText, confirmCallback, cancelCallback)
-	local uniqueId = string.format("%s%s", "WizardsWardrobeDialog", name)
-	ESO_Dialogs[uniqueId] = {
+function WWG.ShowConfirmationDialog( name, dialogText, confirmCallback, cancelCallback )
+	local uniqueId = string.format( "%s%s", "WizardsWardrobeDialog", name )
+	ESO_Dialogs[ uniqueId ] = {
 		canQueue = true,
 		uniqueIdentifier = uniqueId,
-		title = {text = WW.displayName},
-		mainText = {text = dialogText},
+		title = { text = WW.displayName },
+		mainText = { text = dialogText },
 		buttons = {
-			[1] = {
+			[ 1 ] = {
 				text = SI_DIALOG_CONFIRM,
 				callback = function()
 					confirmCallback()
 				end,
 			},
-			[2] = {
+			[ 2 ] = {
 				text = SI_DIALOG_CANCEL,
 				callback = function()
 					if cancelCallback then
@@ -243,26 +250,26 @@ function WWG.ShowConfirmationDialog(name, dialogText, confirmCallback, cancelCal
 		},
 		setup = function() end,
 	}
-	ZO_Dialogs_ShowDialog(uniqueId, nil, {mainTextParams = {}})
+	ZO_Dialogs_ShowDialog( uniqueId, nil, { mainTextParams = {} } )
 end
 
-function WWG.ShowEditDialog(name, dialogText, initialText, confirmCallback, cancelCallback)
-	local uniqueId = string.format("%s%s", "WizardsWardrobeDialog", name)
-	ESO_Dialogs[uniqueId] = {
+function WWG.ShowEditDialog( name, dialogText, initialText, confirmCallback, cancelCallback )
+	local uniqueId = string.format( "%s%s", "WizardsWardrobeDialog", name )
+	ESO_Dialogs[ uniqueId ] = {
 		canQueue = true,
 		uniqueIdentifier = uniqueId,
-		title = {text = WW.displayName},
-		mainText = {text = dialogText},
+		title = { text = WW.displayName },
+		mainText = { text = dialogText },
 		editBox = {},
 		buttons = {
-			[1] = {
+			[ 1 ] = {
 				text = SI_DIALOG_CONFIRM,
-				callback = function(dialog)
-					local input = ZO_Dialogs_GetEditBoxText(dialog)
-					confirmCallback(input)
+				callback = function( dialog )
+					local input = ZO_Dialogs_GetEditBoxText( dialog )
+					confirmCallback( input )
 				end,
 			},
-			[2] = {
+			[ 2 ] = {
 				text = SI_DIALOG_CANCEL,
 				callback = function()
 					if cancelCallback then
@@ -273,5 +280,5 @@ function WWG.ShowEditDialog(name, dialogText, initialText, confirmCallback, canc
 		},
 		setup = function() end,
 	}
-	ZO_Dialogs_ShowDialog(uniqueId, nil, {mainTextParams = {}, initialEditText = initialText})
+	ZO_Dialogs_ShowDialog( uniqueId, nil, { mainTextParams = {}, initialEditText = initialText } )
 end

--- a/src/lang/de.lua
+++ b/src/lang/de.lua
@@ -57,8 +57,8 @@ local language = {
 	WW_MSG_FOOD_COMBAT =
 	"Dein Bufffood ist im Kampf ausgelaufen. Wenn nötig wird dich der Zauberer nach dem Kampf mit %s versorgen.",
 	WW_MSG_NOFOOD = "Kein passendes Bufffood im Inventar gefunden!",
-	WW_MSG_SWAPFAIL = "Setup hat nicht gewechselt, versuche Problemsumgehung, bitte warte einige Sekunden",
-	WW_MSG_SWAPFAIL_DISABLED = "Setup hat nicht gewechselt",
+	WW_MSG_SWAPFAIL = "%s im Setup hat nicht gewechselt, versuche Problemsumgehung, bitte warte einige Sekunden",
+	WW_MSG_SWAPFAIL_DISABLED = "%s im Setup hat nicht gewechselt",
 	WW_MSG_SWAPSUCCESS = "Setup hat erfolgreich geladen",
 	WW_MSG_SWAP_FIX_FAIL = "Alle versuche haben fehlgeschlagen, bitte versuche die Rüstungen / Waffen manuell zu entfernen",
 
@@ -121,6 +121,16 @@ local language = {
 	WW_MENU_VALIDATION_DELAY_TT = "Wähle die Anzahl der ms nachder die Überprüfung passsiert.",
 	WW_MENU_VALIDATION_DELAY_WARN =
 	"Je länger die Verzögerung, desto höher is die Chance falsche positive Warnungen zu haben. Wenn die Verzögerung zu gering ist, könnten unabsichtliche Dinge passieren.",
+	WW_MENU_COMPARISON_DEPTH = "Vergleichstiefe",
+	WW_MENU_COMPARISON_DEPTH_EASY = "Einfach",
+	WW_MENU_COMPARISON_DEPTH_DETAILED = "Detailliert",
+	WW_MENU_COMPARISON_DEPTH_THOROUGH = "Gründlich",
+	WW_MENU_COMPARISON_DEPTH_STRICT = "Streng",
+	WW_MENU_COMPARISON_DEPTH_EASY_TT = "Überprüft nur den Trait, den Waffentyp und das Set.",
+	WW_MENU_COMPARISON_DEPTH_DETAILED_TT = "Überprüft den Trait, den Waffentyp das Set und Qualität.",
+	WW_MENU_COMPARISON_DEPTH_THOROUGH_TT = "Überprüft den Trait, den Waffentyp das Set, Qualität und Verzauberung.",
+	WW_MENU_COMPARISON_DEPTH_STRICT_TT =
+	"Überprüft, ob es genau das gleiche Ausrüstungsteil ist, das gespeichert wurde. Scheiterd, wenn irgendetwas verändert wurde",
 
 
 	-- USER INTERFACE

--- a/src/lang/de.lua
+++ b/src/lang/de.lua
@@ -1,7 +1,8 @@
 local language = {
-	
+
 	-- MESSAGES
-	WW_MSG_FIRSTSTART = "Wenn du zum ersten Mal Wizard's Wardrobe benutzt, sieh dir bitte das FAQ und die Liste der Funktionen auf %s an. Dort werden die meisten Fragen schon beantwortet.",
+	WW_MSG_FIRSTSTART =
+	"Wenn du zum ersten Mal Wizard's Wardrobe benutzt, sieh dir bitte das FAQ und die Liste der Funktionen auf %s an. Dort werden die meisten Fragen schon beantwortet.",
 	WW_MSG_ENOENT = "Ein solcher Eintrag existiert nicht.",
 	WW_MSG_ERROR = "FEHLER!",
 	WW_MSG_LOADSETUP = "Lade Setup [%s] aus [%s].",
@@ -10,7 +11,8 @@ local language = {
 	WW_MSG_DELETESETUP = "Lösche Setup [%s].",
 	WW_MSG_EMPTYSETUP = "Das Setup ist leer.",
 	WW_MSG_FOODENOENT = "Kein passendes Bufffood im Inventar gefunden!",
-	WW_MSG_NOFOODRUNNING = "Es läuft kein Bufffood. Iss etwas und versuche es erneut oder ziehe Bufffood per Drag & Drop auf diesen Button.",
+	WW_MSG_NOFOODRUNNING =
+	"Es läuft kein Bufffood. Iss etwas und versuche es erneut oder ziehe Bufffood per Drag & Drop auf diesen Button.",
 	WW_MSG_NOTFOOD = "Dieser Gegenstand ist kein Bufffood oder wird aktuell noch nicht unterstützt.",
 	WW_MSG_LOADSKILLS = "Lade Skills [%s] aus [%s].",
 	WW_MSG_SAVESKILLS = "Speichere Skills in Setup %s.",
@@ -40,7 +42,8 @@ local language = {
 	WW_MSG_NOTENOUGHSOULGEMS = "Nicht genügend Seelensteine im Beutel gefunden!",
 	WW_MSG_NOPOISONS = "Keine Gifte im Beutel gefunden!",
 	WW_MSG_IMPORTSUCCESS = "Alle Gegenstände erfolgreich importiert.",
-	WW_MSG_IMPORTGEARENOENT = "Es konnten nicht alle Gegenstände importiert werden. Sorge dafür, dass du alle Items im Inventar oder in der Bank hast. Der Trait spielt keine Rolle.",
+	WW_MSG_IMPORTGEARENOENT =
+	"Es konnten nicht alle Gegenstände importiert werden. Sorge dafür, dass du alle Items im Inventar oder in der Bank hast. Der Trait spielt keine Rolle.",
 	WW_MSG_WITHDRAW_SETUP = "Nehme Setup [%s] aus der Bank.",
 	WW_MSG_WITHDRAW_PAGE = "Nehme Setups der Seite [%s] aus der Bank.",
 	WW_MSG_WITHDRAW_FULL = "Item konnte nicht verschoben werden. Bitte sorge für genügend Platz im Beutel.",
@@ -51,27 +54,35 @@ local language = {
 	WW_MSG_TRANSFER_FINISHED = "Alle Items wurden erfolgreich verschoben.",
 	WW_MSG_TRANSFER_TIMEOUT = "Mindestens ein Item steckt fest. Bitte erneut versuchen.",
 	WW_MSG_FOOD_FADED = "Dein Bufffood ist ausgelaufen. Genieße dein %s!",
-	WW_MSG_FOOD_COMBAT = "Dein Bufffood ist im Kampf ausgelaufen. Wenn nötig wird dich der Zauberer nach dem Kampf mit %s versorgen.",
+	WW_MSG_FOOD_COMBAT =
+	"Dein Bufffood ist im Kampf ausgelaufen. Wenn nötig wird dich der Zauberer nach dem Kampf mit %s versorgen.",
 	WW_MSG_NOFOOD = "Kein passendes Bufffood im Inventar gefunden!",
-	
-	
+	WW_MSG_SWAPFAIL = "Setup hat nicht gewechselt, versuche Problemsumgehung, bitte warte einige Sekunden",
+	WW_MSG_SWAPFAIL_DISABLED = "Setup hat nicht gewechselt",
+	WW_MSG_SWAPSUCCESS = "Setup hat erfolgreich geladen",
+	WW_MSG_SWAP_FIX_FAIL = "Alle versuche haben fehlgeschlagen, bitte versuche die Rüstungen / Waffen manuell zu entfernen",
+
+
 	-- ADDON MENU
 	WW_MENU_GENERAL = "Allgemein",
 	WW_MENU_PRINTCHAT = "Meldungen",
 	WW_MENU_PRINTCHAT_TT = "Gibt Meldungen über geladene Setups im Chat oder Benachrichtigungsfenster aus.",
 	WW_MENU_PRINTCHAT_OFF = "Deaktiviert",
 	WW_MENU_PRINTCHAT_CHAT = "Chat",
-	WW_MENU_PRINTCHAT_ALERT = "Benachrichtigung",	
+	WW_MENU_PRINTCHAT_ALERT = "Benachrichtigung",
 	WW_MENU_OVERWRITEWARNING = "Warnung beim Überschreiben",
 	WW_MENU_OVERWRITEWARNING_TT = "Zeigt eine Warnung wenn ein bereits gespeichertes Setup überschrieben wird.",
 	WW_MENU_INVENTORYMARKER = "Inventarmarker",
 	WW_MENU_INVENTORYMARKER_TT = "Zeigt ein kleines Symbol über Items im Inventar, die in Setups gespeichert sind.",
 	WW_MENU_UNEQUIPEMPTY = "Leere Slots ablegen",
-	WW_MENU_UNEQUIPEMPTY_TT = "Wenn im Setup etwas als leer gespeichert ist wird der Gegenstand/Champion Punkt/Skill abgelegt.",
+	WW_MENU_UNEQUIPEMPTY_TT =
+	"Wenn im Setup etwas als leer gespeichert ist wird der Gegenstand/Champion Punkt/Skill abgelegt.",
 	WW_MENU_IGNORE_TABARDS = "Leere Wappenröcke-Slots ignorieren",
-	WW_MENU_IGNORE_TABARDS_TT = "Wenn ein Outfit ohne Wappenrock gespeichert wird, entfernen Sie keinen aktuell ausgerüsteten Wappenrock.",
+	WW_MENU_IGNORE_TABARDS_TT =
+	"Wenn ein Outfit ohne Wappenrock gespeichert wird, entfernen Sie keinen aktuell ausgerüsteten Wappenrock.",
 	WW_MENU_RESETUI = "UI zurücksetzen",
-	WW_MENU_RESETUI_TT = "|cFF0000Dies setzt das Fenster und alle seine Positionen auf den Scenes zurück.|r\nEs muss dann erneut mit /wizard oder dem Hotkey geöffnet werden.",
+	WW_MENU_RESETUI_TT =
+	"|cFF0000Dies setzt das Fenster und alle seine Positionen auf den Scenes zurück.|r\nEs muss dann erneut mit /wizard oder dem Hotkey geöffnet werden.",
 	WW_MENU_AUTOEQUIP = "Automatisches Laden",
 	WW_MENU_AUTOEQUIP_DESC = "Diese Einstellungen steuern, was genau aus dem Setup geladen/gespeichert wird",
 	WW_MENU_AUTOEQUIP_GEAR = "Ausrüsrung",
@@ -82,10 +93,12 @@ local language = {
 	WW_MENU_SUBSTITUTE_OVERLAND = "Offene Welt",
 	WW_MENU_SUBSTITUTE_OVERLAND_TT = "Umfasst auch Gewölbe und öffentliche Verliese.",
 	WW_MENU_SUBSTITUTE_DUNGEONS = "Verliese",
-	WW_MENU_SUBSTITUTE_WARNING = "Diese Optionen aktivieren das Laden von Ersatzsetups außerhalb der unterstützten Zonen. Es ist |cFF0000experimentell|r und wird nicht überall zu 100% funktionieren. Neue Dungeons funktionieren in der Regel besser als alte.",
+	WW_MENU_SUBSTITUTE_WARNING =
+	"Diese Optionen aktivieren das Laden von Ersatzsetups außerhalb der unterstützten Zonen. Es ist |cFF0000experimentell|r und wird nicht überall zu 100% funktionieren. Neue Dungeons funktionieren in der Regel besser als alte.",
 	WW_MENU_PANEL = "Info Panel",
 	WW_MENU_PANEL_ENABLE = "Panel aktivieren",
-	WW_MENU_PANEL_ENABLE_TT = "Zeigt den aktuellen Set- und Seitenname sowie die Zone.\nEin |cF8FF70gelber|r Setname weißt auf ein verzögertes Laden des Setups hin. Ein |cFF7070roter|r Setname bedeutet, dass das aktuelle Setup nicht mehr dem gespeicherten entspricht.",
+	WW_MENU_PANEL_ENABLE_TT =
+	"Zeigt den aktuellen Set- und Seitenname sowie die Zone.\nEin |cF8FF70gelber|r Setname weißt auf ein verzögertes Laden des Setups hin. Ein |cFF7070roter|r Setname bedeutet, dass das aktuelle Setup nicht mehr dem gespeicherten entspricht.",
 	WW_MENU_PANEL_MINI = "Panel verkleinern",
 	WW_MENU_PANEL_MINI_TT = "Blendet Icon und Schriftzug aus und verkleinert die Anzeige.",
 	WW_MENU_PANEL_LOCK = "Anpinnen",
@@ -94,18 +107,29 @@ local language = {
 	WW_MENU_REPAIRARMOR = "Rüstung automatisch reparieren",
 	WW_MENU_REPAIRARMOR_TT = "Am Händler und mit Reparaturmaterialien.",
 	WW_MENU_FILLPOISONS = "Gifte automatisch nachlegen",
-	WW_MENU_FILLPOISONS_TT = "Versucht automatisch Gifte aus dem Inventar nachzulegen.\n|H1:item:76827:308:50:0:0:0:0:0:0:0:0:0:0:0:0:36:1:0:0:0:138240|h|h wird auch mit |H1:item:79690:6:1:0:0:0:0:0:0:0:0:0:0:0:1:36:0:1:0:0:0|h|h ausgetauscht (und andersrum) wenn sonst nicht vorhanden.",
+	WW_MENU_FILLPOISONS_TT =
+	"Versucht automatisch Gifte aus dem Inventar nachzulegen.\n|H1:item:76827:308:50:0:0:0:0:0:0:0:0:0:0:0:0:36:1:0:0:0:138240|h|h wird auch mit |H1:item:79690:6:1:0:0:0:0:0:0:0:0:0:0:0:1:36:0:1:0:0:0|h|h ausgetauscht (und andersrum) wenn sonst nicht vorhanden.",
 	WW_MENU_BUFFFOOD = "Bufffood automatisch verlängern",
-	WW_MENU_BUFFFOOD_TT = "Isst automatisch wieder das passende Bufffood, wenn es ausläuft. Funktioniert nur in Raids und Dungeons.\nSchau in \"WizardsWardrobeConst.lua\" nach welche Bufffoods aktuell supported werden.",
+	WW_MENU_BUFFFOOD_TT =
+	"Isst automatisch wieder das passende Bufffood, wenn es ausläuft. Funktioniert nur in Raids und Dungeons.\nSchau in \"WizardsWardrobeConst.lua\" nach welche Bufffoods aktuell supported werden.",
 	WW_MENU_FIXES_FIXSURFINGWEAPONS = "Fix surfing on weapons",
-	WW_MENU_FIXES_FIXSURFINGWEAPONS_TT = "This will toggle \"Hide Your Helm\" twice every zone swap in order to fix the weapon surf bug.",
-	
-	
+	WW_MENU_FIXES_FIXSURFINGWEAPONS_TT =
+	"This will toggle \"Hide Your Helm\" twice every zone swap in order to fix the weapon surf bug.",
+	WW_MENU_GEAR_SWAP_FIX = "Automatisch fehlerhafte Setups beheben",
+	WW_MENU_WEAPON_GEAR_FIX_TT = "Versucht automatisch das fehlerhafte Wechseln des Setups zu beheben.",
+	WW_MENU_VALIDATION_DELAY = "Überprüfungs Verzögerung",
+	WW_MENU_VALIDATION_DELAY_TT = "Wähle die Anzahl der ms nachder die Überprüfung passsiert.",
+	WW_MENU_VALIDATION_DELAY_WARN =
+	"Je länger die Verzögerung, desto höher is die Chance falsche positive Warnungen zu haben. Wenn die Verzögerung zu gering ist, könnten unabsichtliche Dinge passieren.",
+
+
 	-- USER INTERFACE
-	WW_CHANGELOG = "Achtung! Dieses Update enthält einige große Änderungen. Bitte lies dir das aktuelle Änderungsprotokoll durch, da manche Dinge vielleicht nun anders funktionieren als gewohnt.",
+	WW_CHANGELOG =
+	"Achtung! Dieses Update enthält einige große Änderungen. Bitte lies dir das aktuelle Änderungsprotokoll durch, da manche Dinge vielleicht nun anders funktionieren als gewohnt.",
 	WW_BUTTON_HELP = "|cFFFFFF[Klick]|r um Wiki zu öffnen",
 	WW_BUTTON_SETTINGS = "Einstellungen",
-	WW_BUTTON_CLEARQUEUE = "Warteschlange zurücksetzen\n(Kann eingesetzt werden, falls zu viele Setwechsel eingereiht wurden.)",
+	WW_BUTTON_CLEARQUEUE =
+	"Warteschlange zurücksetzen\n(Kann eingesetzt werden, falls zu viele Setwechsel eingereiht wurden.)",
 	WW_BUTTON_UNDRESS = "Ausrüstung ablegen",
 	WW_BUTTON_PREBUFF = "Prebuff",
 	WW_BUTTON_LABEL = "|cFFFFFF[Klick]|r um Setup zu laden",
@@ -119,10 +143,13 @@ local language = {
 	WW_BUTTON_TOGGLEAUTOEQUIP = "Automatisches Laden\nein-/ausschalten",
 	WW_BUTTON_ADDPAGE = "Seite hinzufügen",
 	WW_BUTTON_ADDSETUP = "Setup hinzufügen",
-	WW_BUTTON_GEAR = "Keine Rüstung gespeichert!\n|cFFFFFF[Shift + Klick]|r drücken um ausgerüstete Gegenstände abzuspeichern oder Items per Drag & Drop auf diesen Button ziehen.",
-	WW_BUTTON_SKILLS = "Keine Skills gespeichert!\n|cFFFFFF[Shift + Klick]|r drücken um ausgerüstete Skills abzuspeichern oder per Drag & Drop auf die Hotbars ziehen.",
+	WW_BUTTON_GEAR =
+	"Keine Rüstung gespeichert!\n|cFFFFFF[Shift + Klick]|r drücken um ausgerüstete Gegenstände abzuspeichern oder Items per Drag & Drop auf diesen Button ziehen.",
+	WW_BUTTON_SKILLS =
+	"Keine Skills gespeichert!\n|cFFFFFF[Shift + Klick]|r drücken um ausgerüstete Skills abzuspeichern oder per Drag & Drop auf die Hotbars ziehen.",
 	WW_BUTTON_CP = "Keine CPs gespeichert!\n|cFFFFFF[Shift + Klick]|r drücken um ausgerüstete Sterne abzuspeichern.",
-	WW_BUTTON_BUFFFOOD = "Kein Bufffood gespeichert!\n|cFFFFFF[Shift + Klick]|r drücken um das aktuelle Bufffood abzuspeichern oder Bufffood per Drag & Drop auf diesen Button ziehen.",
+	WW_BUTTON_BUFFFOOD =
+	"Kein Bufffood gespeichert!\n|cFFFFFF[Shift + Klick]|r drücken um das aktuelle Bufffood abzuspeichern oder Bufffood per Drag & Drop auf diesen Button ziehen.",
 	WW_RENAME_PAGE = "Neuer Name für die Seite:",
 	WW_DELETEPAGE_WARNING = "Seite [%s] wirklich löschen?",
 	WW_OVERWRITESETUP_WARNING = "Setup [%s] wirklich überschreiben?",
@@ -130,128 +157,132 @@ local language = {
 	WW_ENABLE = "Aktivieren",
 	WW_DISABLE = "Deaktivieren",
 	WW_MISSING_GEAR_TT = "Folgende Gegenstände fehlen:\n\n%s\n\n|cFFFFFF[Klick]|r zum Aktualisieren",
-	WW_SUBSTITUTE_EXPLAIN = "Diese Setups werden geladen, wenn auf der jeweiligen Raidseite kein Setup gespeichert ist.\nWenn du diese Funktion nicht nutzen willst, lasse es einfach leer.",
+	WW_SUBSTITUTE_EXPLAIN =
+	"Diese Setups werden geladen, wenn auf der jeweiligen Raidseite kein Setup gespeichert ist.\nWenn du diese Funktion nicht nutzen willst, lasse es einfach leer.",
 	WW_CONDITION_NAME = "Name",
 	WW_CONDITION_BOSS = "Boss",
 	WW_CONDITION_AFTER = "Nach",
 	WW_CONDITION_NONE = "Kein Boss",
 	WW_CONDITION_EVERYWHERE = "Überall",
 	WW_IMPORT = "Importieren",
-	WW_IMPORT_HELP = "Füge hier den exportierten Text mit |cFFFFFF[STRG + V]|r ein. Bitte beachte, dass der Text nicht manipuliert werden darf, da der Import ansonsten fehlschlagen könnte.\nDu benötigst alle Items im Inventar. Die Traits aus dem exportierten Setup werden priorisiert, falls der Gegenstand im Inventar jedoch nicht den richtigen Trait hat werden auch Items mit einem \"falschen\" Trait verwendet.",
+	WW_IMPORT_HELP =
+	"Füge hier den exportierten Text mit |cFFFFFF[STRG + V]|r ein. Bitte beachte, dass der Text nicht manipuliert werden darf, da der Import ansonsten fehlschlagen könnte.\nDu benötigst alle Items im Inventar. Die Traits aus dem exportierten Setup werden priorisiert, falls der Gegenstand im Inventar jedoch nicht den richtigen Trait hat werden auch Items mit einem \"falschen\" Trait verwendet.",
 	WW_IMPORT_TT = "|cFF0000Achtung! Diese Aktion wird das ausgewählte Setup überschreiben.|r",
 	WW_EXPORT = "Exportieren",
-	WW_EXPORT_HELP = "Kopiere den ausgewählten Text mit |cFFFFFF[STRG + C]|r und teile ihn mit anderen.\nEr enthält Ausrüstung, Skills und CP in einem kompakten Format um ihn an einer anderen Stelle wieder zu importieren.",
+	WW_EXPORT_HELP =
+	"Kopiere den ausgewählten Text mit |cFFFFFF[STRG + C]|r und teile ihn mit anderen.\nEr enthält Ausrüstung, Skills und CP in einem kompakten Format um ihn an einer anderen Stelle wieder zu importieren.",
 	WW_CUSTOMCODE = "Lua Code",
 	WW_CUSTOMCODE_HELP = "Dieser Code wird ausgeführt nachdem das Setup geladen wurde.",
 	WW_DUPLICATE = "Duplizieren",
 	WW_DUPLICATE_NAME = "Kopie von %s",
 	WW_LINK_IMPORT = "Zur Garderobe hinzufügen",
-	WW_PREBUFF_HELP = "Spells per Drag and Drop auf die Prebuff Hotbars ziehen.\nWenn Toggle aktiviert ist werden die Spells erst zurückgewechselt, wenn der entsprechende Hotkey erneut gedrückt wird. Ansonsten wird nach dem Casten gewechselt.\nDelay für \"normale\" Spells liegt bei ~500ms, kanalisierende Spells brauchen eventuell mehr.",
-	
-	
+	WW_PREBUFF_HELP =
+	"Spells per Drag and Drop auf die Prebuff Hotbars ziehen.\nWenn Toggle aktiviert ist werden die Spells erst zurückgewechselt, wenn der entsprechende Hotkey erneut gedrückt wird. Ansonsten wird nach dem Casten gewechselt.\nDelay für \"normale\" Spells liegt bei ~500ms, kanalisierende Spells brauchen eventuell mehr.",
+
+
 	-- BOSS & TRIAL NAMES
-	WW_PAGE = "Seite %s",
-	WW_EMPTY = "Leer",
-	WW_UNNAMED = "Unbenannt",
-	WW_TRASH = "Trash",
-	
-	WW_GENERAL = "Allgemein",
-	
-	WW_SUB_NAME = "Ersatzsetups",
-	WW_SUB_BOSS = "Boss",
-	WW_SUB_TRASH = "Trash",
-	
-	WW_PVP_NAME = "Spieler gegen Spieler",
-	
-	WW_AA_NAME = "Ätherisches Archiv",
-	WW_AA_STORMATRO = "Gewitteratronach",
-	WW_AA_STONEATRO = "Grundsteinatronach",
-	WW_AA_VARLARIEL = "Varlariel",
-	WW_AA_MAGE = "Die Magierin",
-	
-	WW_SO_NAME = "Sanctum Ophidia",
-	WW_SO_MANTIKORA = "Besessener Mantikor",
-	WW_SO_TROLL = "Steinbrecher",
-	WW_SO_OZARA = "Ozara",
-	WW_SO_SERPENT = "Die Schlange",
-	
-	WW_HRC_NAME = "Zitadelle von Hel Ra",
-	WW_HRC_RAKOTU = "Ra Kotu",
-	WW_HRC_LOWER = "Yokeda Rok'dun",
-	WW_HRC_UPPER = "Yokeda Kai",
-	WW_HRC_WARRIOR = "Der Krieger",
-	
-	WW_MOL_NAME = "Schlund von Lorkhaj",
-	WW_MOL_ZHAJHASSA = "Zhaj'hassa der Vergessene",
-	WW_MOL_TWINS = "Zwillinge",
-	WW_MOL_RAKKHAT = "Rakkhat",
-	
-	WW_HOF_NAME = "Hallen der Fertigung",
-	WW_HOF_HUNTERKILLER = "Abfänger Negatrix",
-	WW_HOF_HUNTERKILLER_DN = "Negatrix & Positrox",
-	WW_HOF_FACTOTUM = "Perfektioniertes Faktotum",
-	WW_HOF_SPIDER = "Erzaufseher",
-	WW_HOF_COMMITEE = "Reaktor",
-	WW_HOF_COMMITEE_DN = "Komitee",
-	WW_HOF_GENERAL = "Montagegeneral",
-	
-	WW_AS_NAME = "Anstalt Sanctorium",
-	WW_AS_OLMS = "Heiliger Olms der Gerechte",
-	WW_AS_FELMS = "Heiliger Felms der Tapfere",
-	WW_AS_LLOTHIS = "Heiliger Llothis der Fromme",
-	
-	WW_CR_NAME = "Wolkenruh",
-	WW_CR_GALENWE = "Schatten von Galenwe",
-	WW_CR_RELEQUEN = "Schatten von Relequen",
-	WW_CR_SIRORIA = "Schatten von Siroria",
-	WW_CR_ZMAJA = "Z'Maja",
-	
-	WW_SS_NAME = "Sonnspitz",
-	WW_SS_LOKKESTIIZ = "Lokkestiiz",
-	WW_SS_YOLNAHKRIIN = "Yolnahkriin",
-	WW_SS_NAHVIINTAAS = "Nahviintaas",
-	
-	WW_KA_NAME = "Kynes Ägis",
-	WW_KA_YANDIR = "Yandir der Ausweider",
-	WW_KA_VROL = "Kapitän Vrol",
-	WW_KA_FALGRAVN = "Fürst Falgravn",
-	
-	WW_RG_NAME = "Felshain",
-	WW_RG_OAXILTSO = "Oaxiltso",
-	WW_RG_BAHSEI = "Flammenheroldin Bahsei",
-	WW_RG_XALVAKKA = "Xalvakka",
-	WW_RG_SNAKE = "Sonnt-in-Schlangen",
-	WW_RG_ASHTITAN = "Aschtitan",
-	
-	WW_DSR_NAME = "Grauenssegelriff",
-	WW_DSR_LYLANARTURLASSIL = "Lylanar",
+	WW_PAGE                    = "Seite %s",
+	WW_EMPTY                   = "Leer",
+	WW_UNNAMED                 = "Unbenannt",
+	WW_TRASH                   = "Trash",
+
+	WW_GENERAL                 = "Allgemein",
+
+	WW_SUB_NAME                = "Ersatzsetups",
+	WW_SUB_BOSS                = "Boss",
+	WW_SUB_TRASH               = "Trash",
+
+	WW_PVP_NAME                = "Spieler gegen Spieler",
+
+	WW_AA_NAME                 = "Ätherisches Archiv",
+	WW_AA_STORMATRO            = "Gewitteratronach",
+	WW_AA_STONEATRO            = "Grundsteinatronach",
+	WW_AA_VARLARIEL            = "Varlariel",
+	WW_AA_MAGE                 = "Die Magierin",
+
+	WW_SO_NAME                 = "Sanctum Ophidia",
+	WW_SO_MANTIKORA            = "Besessener Mantikor",
+	WW_SO_TROLL                = "Steinbrecher",
+	WW_SO_OZARA                = "Ozara",
+	WW_SO_SERPENT              = "Die Schlange",
+
+	WW_HRC_NAME                = "Zitadelle von Hel Ra",
+	WW_HRC_RAKOTU              = "Ra Kotu",
+	WW_HRC_LOWER               = "Yokeda Rok'dun",
+	WW_HRC_UPPER               = "Yokeda Kai",
+	WW_HRC_WARRIOR             = "Der Krieger",
+
+	WW_MOL_NAME                = "Schlund von Lorkhaj",
+	WW_MOL_ZHAJHASSA           = "Zhaj'hassa der Vergessene",
+	WW_MOL_TWINS               = "Zwillinge",
+	WW_MOL_RAKKHAT             = "Rakkhat",
+
+	WW_HOF_NAME                = "Hallen der Fertigung",
+	WW_HOF_HUNTERKILLER        = "Abfänger Negatrix",
+	WW_HOF_HUNTERKILLER_DN     = "Negatrix & Positrox",
+	WW_HOF_FACTOTUM            = "Perfektioniertes Faktotum",
+	WW_HOF_SPIDER              = "Erzaufseher",
+	WW_HOF_COMMITEE            = "Reaktor",
+	WW_HOF_COMMITEE_DN         = "Komitee",
+	WW_HOF_GENERAL             = "Montagegeneral",
+
+	WW_AS_NAME                 = "Anstalt Sanctorium",
+	WW_AS_OLMS                 = "Heiliger Olms der Gerechte",
+	WW_AS_FELMS                = "Heiliger Felms der Tapfere",
+	WW_AS_LLOTHIS              = "Heiliger Llothis der Fromme",
+
+	WW_CR_NAME                 = "Wolkenruh",
+	WW_CR_GALENWE              = "Schatten von Galenwe",
+	WW_CR_RELEQUEN             = "Schatten von Relequen",
+	WW_CR_SIRORIA              = "Schatten von Siroria",
+	WW_CR_ZMAJA                = "Z'Maja",
+
+	WW_SS_NAME                 = "Sonnspitz",
+	WW_SS_LOKKESTIIZ           = "Lokkestiiz",
+	WW_SS_YOLNAHKRIIN          = "Yolnahkriin",
+	WW_SS_NAHVIINTAAS          = "Nahviintaas",
+
+	WW_KA_NAME                 = "Kynes Ägis",
+	WW_KA_YANDIR               = "Yandir der Ausweider",
+	WW_KA_VROL                 = "Kapitän Vrol",
+	WW_KA_FALGRAVN             = "Fürst Falgravn",
+
+	WW_RG_NAME                 = "Felshain",
+	WW_RG_OAXILTSO             = "Oaxiltso",
+	WW_RG_BAHSEI               = "Flammenheroldin Bahsei",
+	WW_RG_XALVAKKA             = "Xalvakka",
+	WW_RG_SNAKE                = "Sonnt-in-Schlangen",
+	WW_RG_ASHTITAN             = "Aschtitan",
+
+	WW_DSR_NAME                = "Grauenssegelriff",
+	WW_DSR_LYLANARTURLASSIL    = "Lylanar",
 	WW_DSR_LYLANARTURLASSIL_DN = "Lylanar und Turlassil",
-	WW_DSR_GUARDIAN = "Riffwächter",
-	WW_DSR_TALERIA = "Gezeitengeborene Taleria",
-	WW_DSR_SAILRIPPER = "Segelreißerin",
-	WW_DSR_BOWBREAKER = "Bogenbrecher",
+	WW_DSR_GUARDIAN            = "Riffwächter",
+	WW_DSR_TALERIA             = "Gezeitengeborene Taleria",
+	WW_DSR_SAILRIPPER          = "Segelreißerin",
+	WW_DSR_BOWBREAKER          = "Bogenbrecher",
 
 	WW_SE_NAME                 = "Rand des Wahnsinns",
-	WW_SE_DESCENDER			   = "Gewundender Herablasser",
+	WW_SE_DESCENDER            = "Gewundender Herablasser",
 	WW_SE_YASEYLA              = "Exarchanikerin Yaseyla",
 	WW_SE_TWELVANE             = "Erzzaubermeisterin Twelvane",
 	WW_SE_ANSUUL               = "Ansuul die Quälende",
-	
-	WW_MSA_NAME = "Mahlstrom-Arena",
-	
-	WW_VH_NAME = "Grund des Vateshran",
-	
-	WW_DSA_NAME = "Drachenstern-Arena",
-	
-	WW_BRP_NAME = "Schwarzrosengefängnis",
-	WW_BRP_FIRST = "Kampfmagierin Ennodius",
-	WW_BRP_SECOND = "Zähmt-die-Bestien",
-	WW_BRP_THIRD = "Fürstin Minara",
-	WW_BRP_FOURTH = "Alle zusammen",
-	WW_BRP_FIFTH = "Drakeeh der Entfesselte",
-	WW_BRP_FINALROUND = "Letzte Runde",
-	
-	
+
+	WW_MSA_NAME                = "Mahlstrom-Arena",
+
+	WW_VH_NAME                 = "Grund des Vateshran",
+
+	WW_DSA_NAME                = "Drachenstern-Arena",
+
+	WW_BRP_NAME                = "Schwarzrosengefängnis",
+	WW_BRP_FIRST               = "Kampfmagierin Ennodius",
+	WW_BRP_SECOND              = "Zähmt-die-Bestien",
+	WW_BRP_THIRD               = "Fürstin Minara",
+	WW_BRP_FOURTH              = "Alle zusammen",
+	WW_BRP_FIFTH               = "Drakeeh der Entfesselte",
+	WW_BRP_FINALROUND          = "Letzte Runde",
+
+
 	-- KEYBINDS
 	SI_BINDING_NAME_WW_HOTKEY_SHOW_UI = "Wizard's Wardrobe öffnen",
 	SI_BINDING_NAME_WW_HOTKEY_FIXES_FLIP_SHOULDERS = "Schulter reparieren",
@@ -275,12 +306,13 @@ local language = {
 	SI_BINDING_NAME_WW_HOTKEY_PREBUFF_3 = "Prebuff 3",
 	SI_BINDING_NAME_WW_HOTKEY_PREBUFF_4 = "Prebuff 4",
 	SI_BINDING_NAME_WW_HOTKEY_PREBUFF_5 = "Prebuff 5",
-	SI_BINDING_NAME_WW_HOTKEY_SETUP_PREVIOUS = "Vorheriges Setup"
-	SI_BINDING_NAME_WW_HOTKEY_SETUP_NEXT = "Nächstes Setup"
-	SI_BINDING_NAME_WW_HOTKEY_UNDRESS = "Ausziehen"
+	SI_BINDING_NAME_WW_HOTKEY_SETUP_PREVIOUS = "Vorheriges Setup",
+	SI_BINDING_NAME_WW_HOTKEY_SETUP_NEXT = "Nächstes Setup",
+	SI_BINDING_NAME_WW_HOTKEY_UNDRESS = "Ausziehen",
+	SI_BINDING_NAME_WW_HOTKEY_SETUP_FIX = "Versuche das fehlerhafte Wechseln des Setups zu beheben"
 }
 
-for key, value in pairs(language) do
-	SafeAddVersion(key, 1)
-	ZO_CreateStringId(key, value)
+for key, value in pairs( language ) do
+	SafeAddVersion( key, 1 )
+	ZO_CreateStringId( key, value )
 end

--- a/src/lang/de.lua
+++ b/src/lang/de.lua
@@ -66,10 +66,12 @@ local language = {
 	-- ADDON MENU
 	WW_MENU_GENERAL = "Allgemein",
 	WW_MENU_PRINTCHAT = "Meldungen",
-	WW_MENU_PRINTCHAT_TT = "Gibt Meldungen über geladene Setups im Chat oder Benachrichtigungsfenster aus.",
+	WW_MENU_PRINTCHAT_TT =
+	"Gibt Meldungen über geladene Setups im Chat, Benachrichtigungsfenster oder als 'Center Screen Announcement' aus.",
 	WW_MENU_PRINTCHAT_OFF = "Deaktiviert",
 	WW_MENU_PRINTCHAT_CHAT = "Chat",
 	WW_MENU_PRINTCHAT_ALERT = "Benachrichtigung",
+	WW_MENU_PRINTCHAT_ANNOUNCEMENT = "Announcement",
 	WW_MENU_OVERWRITEWARNING = "Warnung beim Überschreiben",
 	WW_MENU_OVERWRITEWARNING_TT = "Zeigt eine Warnung wenn ein bereits gespeichertes Setup überschrieben wird.",
 	WW_MENU_INVENTORYMARKER = "Inventarmarker",

--- a/src/lang/en.lua
+++ b/src/lang/en.lua
@@ -56,15 +56,21 @@ local language = {
 	WW_MSG_FOOD_COMBAT =
 	"Your buff food just ran out mid combat. The wizard will provide you with %s after the combat if still needed.",
 	WW_MSG_NOFOOD = "Could not find any matching buff food in your inventory!",
+	WW_MSG_SWAPFAIL = "%s in your Setup failed to swap, attempting workaround, please wait a few seconds",
+	WW_MSG_SWAPFAIL_DISABLED = "%s in your Setup failed to swap",
+	WW_MSG_SWAPSUCCESS = "Setup successfully loaded",
+	WW_MSG_SWAP_FIX_FAIL = "All workarounds have failed, please try to manually unequip the stuck piece",
 
 
 	-- ADDON MENU
 	WW_MENU_GENERAL = "General",
 	WW_MENU_PRINTCHAT = "Print messages",
-	WW_MENU_PRINTCHAT_TT = "Prints messages about loaded setups into the chat or the alert notifications",
+	WW_MENU_PRINTCHAT_TT =
+	"Prints messages about loaded setups into the chat, the alert notifications or the center screen announcements",
 	WW_MENU_PRINTCHAT_OFF = "Disabled",
 	WW_MENU_PRINTCHAT_CHAT = "Chat",
 	WW_MENU_PRINTCHAT_ALERT = "Alert",
+	WW_MENU_PRINTCHAT_ANNOUNCEMENT = "Announcement",
 	WW_MENU_OVERWRITEWARNING = "Show warning on overwrite",
 	WW_MENU_OVERWRITEWARNING_TT = "Shows a warning if an already saved setup is overwritten.",
 	WW_MENU_INVENTORYMARKER = "Inventory marker",
@@ -109,6 +115,22 @@ local language = {
 	WW_MENU_FIXES_FIXSURFINGWEAPONS = "Fix surfing on weapons",
 	WW_MENU_FIXES_FIXSURFINGWEAPONS_TT =
 	"This will toggle \"Hide Your Helm\" twice every zone swap in order to fix the weapon surf bug.",
+	WW_MENU_WEAPON_GEAR_FIX = "Fix failed gear swaps.",
+	WW_MENU_WEAPON_GEAR_FIX_TT = "Automates the steps we take to fix failed gear swaps",
+	WW_MENU_VALIDATION_DELAY = "Validation delay",
+	WW_MENU_VALIDATION_DELAY_TT = "Chose here the amount of MS after which the setup validation takes place",
+	WW_MENU_VALIDATION_DELAY_WARN =
+	"The longer the delay the lower the chance to have false positives. If its too low, it might cause unintended behavior.",
+	WW_MENU_COMPARISON_DEPTH = "Comparison depth",
+	WW_MENU_COMPARISON_DEPTH_EASY = "Easy",
+	WW_MENU_COMPARISON_DEPTH_DETAILED = "Detailed",
+	WW_MENU_COMPARISON_DEPTH_THOROUGH = "Thorough",
+	WW_MENU_COMPARISON_DEPTH_STRICT = "Strict",
+	WW_MENU_COMPARISON_DEPTH_EASY_TT = "Will only check the trait, the weapon type and the set.",
+	WW_MENU_COMPARISON_DEPTH_DETAILED_TT = "Will check the trait, the weapon type the set and quality.",
+	WW_MENU_COMPARISON_DEPTH_THOROUGH_TT = "Will check the trait, the weapon type the set, quality and enchantment.",
+	WW_MENU_COMPARISON_DEPTH_STRICT_TT =
+	"Will check if its the exact same piece of gear that was saved. Will fail if you change anything.",
 
 
 	-- USER INTERFACE
@@ -297,10 +319,11 @@ local language = {
 	SI_BINDING_NAME_WW_HOTKEY_UNDRESS = "Undress",
 	SI_BINDING_NAME_WW_HOTKEY_SETUP_PREVIOUS = "Equip previous setup",
 	SI_BINDING_NAME_WW_HOTKEY_SETUP_CURRENT = "Reload current setup",
-	SI_BINDING_NAME_WW_HOTKEY_SETUP_NEXT = "Equip next setup"
+	SI_BINDING_NAME_WW_HOTKEY_SETUP_NEXT = "Equip next setup",
+	SI_BINDING_NAME_WW_HOTKEY_SETUP_FIX = "Try to fix failed setup swap"
 }
 
-for key, value in pairs(language) do
-	SafeAddVersion(key, 1)
-	ZO_CreateStringId(key, value)
+for key, value in pairs( language ) do
+	SafeAddVersion( key, 1 )
+	ZO_CreateStringId( key, value )
 end

--- a/src/modules/WizardsWardrobeTransfer.lua
+++ b/src/modules/WizardsWardrobeTransfer.lua
@@ -10,98 +10,96 @@ function WWT.Init()
 	WWT.CreateTransferDialog()
 end
 
-function WWT.Export(zone, pageId, index)
-	local setup = Setup:FromStorage(zone.tag, pageId, index)
-	
+function WWT.Export( zone, pageId, index )
+	local setup = Setup:FromStorage( zone.tag, pageId, index )
+
 	if setup:IsEmpty() then
 		return
 	end
-	
+
 	local exportTable = {}
-	
+
 	exportTable.name = setup:GetName()
-	
+
 	-- skills
 	exportTable.skills = {}
 	for hotbar = 0, 1 do
-		exportTable.skills[tostring(hotbar)] = {}
+		exportTable.skills[ tostring( hotbar ) ] = {}
 		for slot = 3, 8 do
-			local abilityId = setup:GetHotbar(hotbar)[slot]
-			exportTable.skills[tostring(hotbar)][tostring(slot)] = abilityId
+			local abilityId = setup:GetHotbar( hotbar )[ slot ]
+			exportTable.skills[ tostring( hotbar ) ][ tostring( slot ) ] = abilityId
 		end
 	end
-	
+
 	-- gear
 	exportTable.gear = {}
-	for _, gearSlot in ipairs(WW.GEARSLOTS) do
-		local savedGear = setup:GetGearInSlot(gearSlot)
+	for _, gearSlot in ipairs( WW.GEARSLOTS ) do
+		local savedGear = setup:GetGearInSlot( gearSlot )
 		if savedGear then
 			if gearSlot ~= EQUIP_SLOT_POISON
 				and gearSlot ~= EQUIP_SLOT_BACKUP_POISON
 				and gearSlot ~= EQUIP_SLOT_COSTUME then
-				
-				exportTable.gear[tostring(gearSlot)] = {
-					GetItemLinkEquipType(savedGear.link), -- equipType
-					({GetItemLinkSetInfo(savedGear.link, false)})[6], -- setId
-					({GetItemLinkTraitInfo(savedGear.link)})[1], -- traitType
+				exportTable.gear[ tostring( gearSlot ) ] = {
+					GetItemLinkEquipType( savedGear.link ), -- equipType
+					({ GetItemLinkSetInfo( savedGear.link, false ) })[ 6 ], -- setId
+					({ GetItemLinkTraitInfo( savedGear.link ) })[ 1 ], -- traitType
 				}
 			end
 		end
 	end
-	
+
 	-- cp
 	exportTable.cp = {}
 	for slotIndex = 1, 12 do
-		exportTable.cp[tostring(slotIndex)] = setup:GetCP()[slotIndex]
+		exportTable.cp[ tostring( slotIndex ) ] = setup:GetCP()[ slotIndex ]
 	end
-	
+
 	-- food
 	exportTable.food = setup:GetFood().id
-	
-	return json.encode(exportTable)
+
+	return json.encode( exportTable )
 end
 
-function WWT.Import(jsonText, zone, pageId, index)
-	
+function WWT.Import( jsonText, zone, pageId, index )
 	if not jsonText or #jsonText == 0 then
 		return
 	end
-	
-	local importTable = json.decode(jsonText)
-	
+
+	local importTable = json.decode( jsonText )
+
 	if not importTable then
 		return
 	end
-	
+
 	local setup = Setup:New()
-	
-	setup:SetName(importTable.name)
-	
+
+	setup:SetName( importTable.name )
+
 	-- skills
 	local skillTable = {}
 	for hotbar = 0, 1 do
-		skillTable[hotbar] = {}
+		skillTable[ hotbar ] = {}
 		for slot = 3, 8 do
-			local abilityId = importTable.skills[tostring(hotbar)][tostring(slot)]
-			skillTable[hotbar][slot] = abilityId
+			local abilityId = importTable.skills[ tostring( hotbar ) ][ tostring( slot ) ]
+			skillTable[ hotbar ][ slot ] = abilityId
 		end
 	end
-	setup:SetSkills(skillTable)
-	
+	setup:SetSkills( skillTable )
+
 	-- gear
-	local gearTable = {mythic = nil}
+	local gearTable = { mythic = nil }
 	local filter = {}
 	local missing = false
-	for _, gearSlot in ipairs(WW.GEARSLOTS) do
-		local gear = importTable.gear[tostring(gearSlot)]
-		if gear and gear[1] > 0 then
-			local bag, slot = WWT.SearchItem(gear[1], gear[2], gear[3], filter)
+	for _, gearSlot in ipairs( WW.GEARSLOTS ) do
+		local gear = importTable.gear[ tostring( gearSlot ) ]
+		if gear and gear[ 1 ] > 0 then
+			local bag, slot = WWT.SearchItem( gear[ 1 ], gear[ 2 ], gear[ 3 ], filter )
 			if bag and slot then
-				gearTable[gearSlot] = {
-					id = Id64ToString(GetItemUniqueId(bag, slot)),
-					link = GetItemLink(bag, slot, LINK_STYLE_DEFAULT),
+				gearTable[ gearSlot ] = {
+					id = Id64ToString( GetItemUniqueId( bag, slot ) ),
+					link = GetItemLink( bag, slot, LINK_STYLE_DEFAULT ),
 				}
-				if WW.IsMythic(bag, slot) then
+				if WW.IsMythic( bag, slot ) then
 					gearTable.mythic = gearSlot
 				end
 			else
@@ -109,173 +107,177 @@ function WWT.Import(jsonText, zone, pageId, index)
 			end
 		end
 	end
-	if missing then WW.Log(GetString(WW_MSG_IMPORTGEARENOENT), WW.LOGTYPES.ERROR) else WW.Log(GetString(WW_MSG_IMPORTSUCCESS)) end
-	setup:SetGear(gearTable)
-	
+	if missing then WW.Log( GetString( WW_MSG_IMPORTGEARENOENT ), WW.LOGTYPES.ERROR ) else WW.Log( GetString(
+		WW_MSG_IMPORTSUCCESS ) ) end
+	setup:SetGear( gearTable )
+
 	-- cp
 	local cpTable = {}
 	for slotIndex = 1, 12 do
-		cpTable[slotIndex] = importTable.cp[tostring(slotIndex)]
+		cpTable[ slotIndex ] = importTable.cp[ tostring( slotIndex ) ]
 	end
-	setup:SetCP(cpTable)
-	
+	setup:SetCP( cpTable )
+
 	-- food
-	foodIndex = WW.FindFood({importTable.food})
+	foodIndex = WW.FindFood( { importTable.food } )
 	if foodIndex then
-		local foodLink = GetItemLink(BAG_BACKPACK, foodIndex, LINK_STYLE_DEFAULT)
-		local foodId = GetItemLinkItemId(foodLink)
-		
-		setup:SetFood({
+		local foodLink = GetItemLink( BAG_BACKPACK, foodIndex, LINK_STYLE_DEFAULT )
+		local foodId = GetItemLinkItemId( foodLink )
+
+		setup:SetFood( {
 			link = foodLink,
 			id = foodId,
-		})
+		} )
 	end
-	
-	setup:ToStorage(zone.tag, pageId, index)
-	WW.gui.RefreshSetup(WW.gui.GetSetupControl(index), setup)
+
+	setup:ToStorage( zone.tag, pageId, index )
+	WW.gui.RefreshSetup( WW.gui.GetSetupControl( index ), setup )
 end
 
-function WWT.SearchItem(equipType, setId, prefTraitType, filter)
+function WWT.SearchItem( equipType, setId, prefTraitType, filter )
 	if not equipType or equipType == 0 then return nil end
 	if not setId or setId == 0 then return nil end
 	if not prefTraitType or prefTraitType == 0 then return nil end
 	local itemList = {}
-	
-	local bagList = {BAG_WORN, BAG_BACKPACK}
+
+	local bagList = { BAG_WORN, BAG_BACKPACK }
 	local bankBag = GetBankingBag()
-	if IsBankOpen() and not WW.DISABLEDBAGS[bankBag] then
-		table.insert(bagList, bankBag)
+	if IsBankOpen() and not WW.DISABLEDBAGS[ bankBag ] then
+		table.insert( bagList, bankBag )
 		if bankBag == BAG_BANK and IsESOPlusSubscriber() then
-			table.insert(bagList, BAG_SUBSCRIBER_BANK)
+			table.insert( bagList, BAG_SUBSCRIBER_BANK )
 		end
 	end
-	
-	for _, bag in ipairs(bagList) do
-		for slot = 0, GetBagSize(bag) do
-			local itemLink = GetItemLink(bag, slot, LINK_STYLE_DEFAULT)
-			
-			local lookupEquipType = GetItemLinkEquipType(itemLink)
-			local lookupSetId = ({GetItemLinkSetInfo(itemLink, false)})[6]
-			local lookupTraitType = ({GetItemLinkTraitInfo(itemLink)})[1]
+
+	for _, bag in ipairs( bagList ) do
+		for slot = 0, GetBagSize( bag ) do
+			local itemLink = GetItemLink( bag, slot, LINK_STYLE_DEFAULT )
+
+			local lookupEquipType = GetItemLinkEquipType( itemLink )
+			local lookupSetId = ({ GetItemLinkSetInfo( itemLink, false ) })[ 6 ]
+			local lookupTraitType = ({ GetItemLinkTraitInfo( itemLink ) })[ 1 ]
 
 			if lookupEquipType == equipType and lookupSetId == setId then
 				-- sort out items that were already found before (e.g. first set ring)
-				local lookupUniqueId = Id64ToString(GetItemUniqueId(bag, slot))
-				if lookupTraitType == prefTraitType and not filter[lookupUniqueId] then
-					filter[lookupUniqueId] = true
+				local lookupUniqueId = Id64ToString( GetItemUniqueId( bag, slot ) )
+				if lookupTraitType == prefTraitType and not filter[ lookupUniqueId ] then
+					filter[ lookupUniqueId ] = true
 					return bag, slot -- right trait, return location
 				end
-				
+
 				-- wrong trait, add to list
-				table.insert(itemList, {
+				table.insert( itemList, {
 					bag = bag,
 					slot = slot,
 					trait = lookupTraitType,
-				})
+				} )
 			end
 		end
 	end
-	for _, item in ipairs(itemList) do
-		local lookupUniqueId = Id64ToString(GetItemUniqueId(item.bag, item.slot))
-		if not filter[lookupUniqueId] then
-			filter[lookupUniqueId] = true
+	for _, item in ipairs( itemList ) do
+		local lookupUniqueId = Id64ToString( GetItemUniqueId( item.bag, item.slot ) )
+		if not filter[ lookupUniqueId ] then
+			filter[ lookupUniqueId ] = true
 			return item.bag, item.slot
 		end
 	end
 	return nil
 end
 
-function WWT.ShowExportDialog(zone, pageId, index)
-	local text = WWT.Export(zone, pageId, index)
-	WWG.SetTooltip(WWT.helpButton, TOP, GetString(WW_EXPORT_HELP))
-	WWT.title:SetText(GetString(WW_EXPORT):upper())
-	WWT.editBox:SetText(tostring(text or ""))
-	WWT.importButton:SetHidden(true)
-	WWT.dialogWindow:SetHidden(false)
-	SCENE_MANAGER:SetInUIMode(true, false)
+function WWT.ShowExportDialog( zone, pageId, index )
+	local text = WWT.Export( zone, pageId, index )
+	WWG.SetTooltip( WWT.helpButton, TOP, GetString( WW_EXPORT_HELP ) )
+	WWT.title:SetText( GetString( WW_EXPORT ):upper() )
+	WWT.editBox:SetText( tostring( text or "" ) )
+	WWT.importButton:SetHidden( true )
+	WWT.dialogWindow:SetHidden( false )
+	SCENE_MANAGER:SetInUIMode( true, false )
 	WWT.editBox:TakeFocus()
 	WWT.editBox:SelectAll()
 end
 
-function WWT.ShowImportDialog(zone, pageId, index)
-	WWG.SetTooltip(WWT.helpButton, TOP, GetString(WW_IMPORT_HELP))
-	WWT.title:SetText(GetString(WW_IMPORT):upper())
+function WWT.ShowImportDialog( zone, pageId, index )
+	WWG.SetTooltip( WWT.helpButton, TOP, GetString( WW_IMPORT_HELP ) )
+	WWT.title:SetText( GetString( WW_IMPORT ):upper() )
 	WWT.editBox:Clear()
-	WWT.importButton:SetHidden(false)
-	WWT.dialogWindow:SetHidden(false)
-	SCENE_MANAGER:SetInUIMode(true, false)
+	WWT.importButton:SetHidden( false )
+	WWT.dialogWindow:SetHidden( false )
+	SCENE_MANAGER:SetInUIMode( true, false )
 	WWT.editBox:TakeFocus()
-	WWT.importButton:SetHandler("OnClicked", function(self)
-		WWT.dialogWindow:SetHidden(true)
+	WWT.importButton:SetHandler( "OnClicked", function( self )
+		WWT.dialogWindow:SetHidden( true )
 		local text = WWT.editBox:GetText()
-		WWT.Import(text, zone, pageId, index)
-	end)
+		WWT.Import( text, zone, pageId, index )
+	end )
 end
 
 function WWT.CreateTransferDialog()
-	local window = WINDOW_MANAGER:CreateTopLevelWindow("WizardsWardrobeTransfer")
+	local window = WINDOW_MANAGER:CreateTopLevelWindow( "WizardsWardrobeTransfer" )
 	WWT.dialogWindow = window
-	window:SetDimensions(GuiRoot:GetWidth() + 8, GuiRoot:GetHeight() + 8)
-	window:SetAnchor(CENTER, GUI_ROOT, CENTER, 0, 0)
-	window:SetDrawTier(DT_HIGH)
-	window:SetClampedToScreen(false)
-	window:SetMouseEnabled(true)
-	window:SetMovable(false)
-	window:SetHidden(true)
-	
-	local fullscreenBackground = WINDOW_MANAGER:CreateControlFromVirtual(window:GetName() .. "BG", window, "ZO_DefaultBackdrop")
-	fullscreenBackground:SetAlpha(0.7)
-	
-	local dialog = WINDOW_MANAGER:CreateControl(window:GetName() .. "Dialog", window, CT_CONTROL)
-	dialog:SetDimensions(350, 500)
-	dialog:SetAnchor(CENTER, window, CENTER, 0, 0)
-	dialog:SetMouseEnabled(true)
-	
-	local dialogBackground = WINDOW_MANAGER:CreateControlFromVirtual(dialog:GetName() .. "BG", dialog, "ZO_DefaultBackdrop")
-	dialogBackground:SetAlpha(0.95)
-	
-	local helpButton = WINDOW_MANAGER:CreateControl(dialog:GetName() .. "Help", dialog, CT_BUTTON)
+	window:SetDimensions( GuiRoot:GetWidth() + 8, GuiRoot:GetHeight() + 8 )
+	window:SetAnchor( CENTER, GUI_ROOT, CENTER, 0, 0 )
+	window:SetDrawTier( DT_HIGH )
+	window:SetClampedToScreen( false )
+	window:SetMouseEnabled( true )
+	window:SetMovable( false )
+	window:SetHidden( true )
+
+	local fullscreenBackground = WINDOW_MANAGER:CreateControlFromVirtual( window:GetName() .. "BG", window,
+		"ZO_DefaultBackdrop" )
+	fullscreenBackground:SetAlpha( 0.7 )
+
+	local dialog = WINDOW_MANAGER:CreateControl( window:GetName() .. "Dialog", window, CT_CONTROL )
+	dialog:SetDimensions( 350, 500 )
+	dialog:SetAnchor( CENTER, window, CENTER, 0, 0 )
+	dialog:SetMouseEnabled( true )
+
+	local dialogBackground = WINDOW_MANAGER:CreateControlFromVirtual( dialog:GetName() .. "BG", dialog, "ZO_DefaultBackdrop" )
+	dialogBackground:SetAlpha( 0.95 )
+
+	local helpButton = WINDOW_MANAGER:CreateControl( dialog:GetName() .. "Help", dialog, CT_BUTTON )
 	WWT.helpButton = helpButton
-	helpButton:SetDimensions(25, 25)
-	helpButton:SetAnchor(TOPRIGHT, dialog, TOPRIGHT, -6 -30, 5)
-	helpButton:SetState(BSTATE_NORMAL)
-	helpButton:SetNormalTexture("/esoui/art/menubar/menubar_help_up.dds")
-	helpButton:SetMouseOverTexture("/esoui/art/menubar/menubar_help_over.dds")
-	helpButton:SetPressedTexture("/esoui/art/menubar/menubar_help_up.dds")
-	
-	local hideButton = WINDOW_MANAGER:CreateControl(dialog:GetName() .. "Hide", dialog, CT_BUTTON)
-	hideButton:SetDimensions(25, 25)
-	hideButton:SetAnchor(TOPRIGHT, dialog, TOPRIGHT, -6, 6)
-	hideButton:SetState(BSTATE_NORMAL)
-	hideButton:SetClickSound(SOUNDS.DIALOG_HIDE)
-	hideButton:SetNormalTexture("/esoui/art/buttons/decline_up.dds")
-	hideButton:SetMouseOverTexture("/esoui/art/buttons/decline_over.dds")
-	hideButton:SetPressedTexture("/esoui/art/buttons/decline_down.dds")
-	hideButton:SetHandler("OnClicked", function(self) window:SetHidden(true) end)
-	
-	local title = WINDOW_MANAGER:CreateControl(dialog:GetName() .. "Title", dialog, CT_LABEL)
+	helpButton:SetDimensions( 25, 25 )
+	helpButton:SetAnchor( TOPRIGHT, dialog, TOPRIGHT, -6 - 30, 5 )
+	helpButton:SetState( BSTATE_NORMAL )
+	helpButton:SetNormalTexture( "/esoui/art/menubar/menubar_help_up.dds" )
+	helpButton:SetMouseOverTexture( "/esoui/art/menubar/menubar_help_over.dds" )
+	helpButton:SetPressedTexture( "/esoui/art/menubar/menubar_help_up.dds" )
+
+	local hideButton = WINDOW_MANAGER:CreateControl( dialog:GetName() .. "Hide", dialog, CT_BUTTON )
+	hideButton:SetDimensions( 25, 25 )
+	hideButton:SetAnchor( TOPRIGHT, dialog, TOPRIGHT, -6, 6 )
+	hideButton:SetState( BSTATE_NORMAL )
+	hideButton:SetClickSound( SOUNDS.DIALOG_HIDE )
+	hideButton:SetNormalTexture( "/esoui/art/buttons/decline_up.dds" )
+	hideButton:SetMouseOverTexture( "/esoui/art/buttons/decline_over.dds" )
+	hideButton:SetPressedTexture( "/esoui/art/buttons/decline_down.dds" )
+	hideButton:SetHandler( "OnClicked", function( self ) window:SetHidden( true ) end )
+
+	local title = WINDOW_MANAGER:CreateControl( dialog:GetName() .. "Title", dialog, CT_LABEL )
 	WWT.title = title
-	title:SetAnchor(CENTER, dialog, TOP, 0, 25)
-	title:SetVerticalAlignment(TEXT_ALIGN_CENTER)
-	title:SetHorizontalAlignment(TEXT_ALIGN_CENTER) 
-	title:SetFont("ZoFontWinH1")
-	
-	local editBox = WINDOW_MANAGER:CreateControlFromVirtual(dialog:GetName() .. "EditBox", dialog, "ZO_DefaultEditMultiLine")
+	title:SetAnchor( CENTER, dialog, TOP, 0, 25 )
+	title:SetVerticalAlignment( TEXT_ALIGN_CENTER )
+	title:SetHorizontalAlignment( TEXT_ALIGN_CENTER )
+	title:SetFont( "ZoFontWinH1" )
+
+	local editBox = WINDOW_MANAGER:CreateControlFromVirtual( dialog:GetName() .. "EditBox", dialog, "ZO_DefaultEditMultiLine" )
 	WWT.editBox = editBox
-	editBox:SetDimensions(320, 350)
-	editBox:SetAnchor(CENTER, dialog, CENTER, 0, 0)
-	editBox:SetMaxInputChars(1000)
-	
-	local editBoxBackground = WINDOW_MANAGER:CreateControlFromVirtual(dialog:GetName() .. editBox:GetName() .. "BG", dialog, "ZO_EditBackdrop")
-	editBoxBackground:SetDimensions(editBox:GetWidth() + 10, editBox:GetHeight() + 10)
-	editBoxBackground:SetAnchor(CENTER, dialog, CENTER, 0, 0)
-	editBoxBackground:SetAlpha(0.9)
-	
-	local importButton = WINDOW_MANAGER:CreateControlFromVirtual(dialog:GetName() .. "ImportButton", dialog, "ZO_DefaultButton")
+	editBox:SetDimensions( 320, 350 )
+	editBox:SetAnchor( CENTER, dialog, CENTER, 0, 0 )
+	editBox:SetMaxInputChars( 1000 )
+
+	local editBoxBackground = WINDOW_MANAGER:CreateControlFromVirtual( dialog:GetName() .. editBox:GetName() .. "BG", dialog,
+		"ZO_EditBackdrop" )
+	editBoxBackground:SetDimensions( editBox:GetWidth() + 10, editBox:GetHeight() + 10 )
+	editBoxBackground:SetAnchor( CENTER, dialog, CENTER, 0, 0 )
+	editBoxBackground:SetAlpha( 0.9 )
+
+	local importButton = WINDOW_MANAGER:CreateControlFromVirtual( dialog:GetName() .. "ImportButton", dialog,
+		"ZO_DefaultButton" )
 	WWT.importButton = importButton
-	importButton:SetDimensions(150, 25)
-	importButton:SetAnchor(CENTER, dialog, BOTTOM, 0, -30)
-	importButton:SetText(GetString(WW_IMPORT))
-	importButton:SetClickSound(SOUNDS.DIALOG_ACCEPT)
-	WWG.SetTooltip(importButton, "TOP", GetString(WW_IMPORT_TT))
+	importButton:SetDimensions( 150, 25 )
+	importButton:SetAnchor( CENTER, dialog, BOTTOM, 0, -30 )
+	importButton:SetText( GetString( WW_IMPORT ) )
+	importButton:SetClickSound( SOUNDS.DIALOG_ACCEPT )
+	WWG.SetTooltip( importButton, "TOP", GetString( WW_IMPORT_TT ) )
 end

--- a/src/zones/SE.lua
+++ b/src/zones/SE.lua
@@ -10,8 +10,7 @@ SE.tag = "SE"
 SE.icon = "/esoui/art/icons/achievement_u38_vtrial_meta.dds"
 SE.priority = 12
 SE.id = 1427
-SE.node = 434 -- Not sure whats the use of this. I used a random positive number
-
+SE.node = 534
 SE.bosses = {
     [ 1 ] = {
         name = GetString( WW_TRASH ),


### PR DESCRIPTION
#### Setup Validation
- Added a setup validation which will notify users if the setup did not swap correctly (has 4 comparison levels adjustable in the settings.
   - This happens after a delay, since the addon needs some time to swap things. This delay is adjustable in the settings.
- Added an automatic list of steps to fix the failed setup. This is turned off by default.
- Added a keybind to do these steps "non automatically"
- Added logging (and a delete log functionality) which saves occurences when setups failed to swap so we may finally get to the bottom of this
- Added a red color on the info panel which colors the name if the setup failed to swap.
- Added a confirmation if the setup swapped correctly (at the time of writing, this only notifies users if any gear swapped, if 2 setups have the same gear it will not notify them, this may be changed at a later time.)
#### Misc
- Added the ability to chose Center Screen Announcements for the messages given to the user
- Added EA Pages (thanks to @yachoor ) 
   - The automatic swap feature does not work in EA since the content is inherently random and i do not think its feasible to add this
- Changed the Sanity's Edge ID so now the porting feature works too