### PR TITLE
1.16.1

### DIFF
--- a/src/WizardsWardrobe.lua
+++ b/src/WizardsWardrobe.lua
@@ -7,7 +7,7 @@ WW.name = "WizardsWardrobe"
 WW.simpleName = "Wizard's Wardrobe"
 WW.displayName =
 "|c18bed8W|c26c2d1i|c35c6c9z|c43cac2a|c52cebar|c60d1b3d|c6fd5ab'|c7dd9a4s|c8cdd9d |c9ae195W|ca8e58ea|cb7e986r|cc5ed7fd|cd4f077r|ce2f470o|cf1f868b|cfffc61e|r"
-WW.version = "1.16.0"
+WW.version = "1.16.1"
 WW.zones = {}
 WW.currentIndex = 0
 
@@ -63,7 +63,7 @@ function WW.LoadSetup( zone, pageId, index, auto )
 
 	setup:ExecuteCode( setup, zone, pageId, index, auto )
 	WW.currentIndex = index
-
+	WWV.SetupFailWorkaround()
 	return true
 end
 
@@ -371,7 +371,7 @@ function WW.MoveItems( itemTaskList )
 				CallSecureProtected( "RequestMoveItem", item.sourceBag, item.sourceSlot, item.destBag, item.destSlot, 1 )
 			end
 		end
-		WWV.SetupFailWorkaround()
+
 		WWQ.Push( itemTask, item.delay )
 	end
 end

--- a/src/WizardsWardrobe.txt
+++ b/src/WizardsWardrobe.txt
@@ -60,3 +60,4 @@ zones/RG.lua
 zones/DSR.lua
 zones/SE.lua
 zones/BRP.lua
+zones/EA.lua

--- a/src/WizardsWardrobe.txt
+++ b/src/WizardsWardrobe.txt
@@ -1,6 +1,6 @@
 ## Title: Wizard's Wardrobe
 ## Author: ownedbynico, |c268074JN_Slevin|r, |c00a313Ghostbane|r
-## Version: 1.16.0
+## Version: 1.16.1
 ## Description: Throw all your setups into the wardrobe and let the wizard equip them exactly when you need it.
 ## APIVersion: 101040
 ## DependsOn: LibAddonMenu-2.0 LibChatMessage>=105 LibDebugLogger LibAsync

--- a/src/WizardsWardrobeSetupValidation.lua
+++ b/src/WizardsWardrobeSetupValidation.lua
@@ -21,12 +21,12 @@ local WORKAROUND_FOUR         = 4
 
 
 function WWV.CompareItemLinks( linkEquipped, linkSaved, uniqueIdEquipped, uniqueIdSaved )
-    local traitEquipped             = GetItemLinkTraitInfo( linkEquipped )
-    local weaponTypeEquipped        = GetItemLinkWeaponType( linkEquipped )
-    local weaponTypeSaved           = GetItemLinkWeaponType( linkSaved )
-    local traitSaved                = GetItemLinkTraitInfo( linkSaved )
-    local _, _, _, _, setIdEquipped = GetItemLinkSetInfo( linkEquipped )
-    local _, _, _, _, setIdSaved    = GetItemLinkSetInfo( linkSaved )
+    local traitEquipped               = GetItemLinkTraitInfo( linkEquipped )
+    local traitSaved                  = GetItemLinkTraitInfo( linkSaved )
+    local weaponTypeEquipped          = GetItemLinkWeaponType( linkEquipped )
+    local weaponTypeSaved             = GetItemLinkWeaponType( linkSaved )
+    local _, _, _, _, _, setIdEquipped = GetItemLinkSetInfo( linkEquipped )
+    local _, _, _, _, _, setIdSaved   = GetItemLinkSetInfo( linkSaved )
 
     if WW.settings.comparisonDepth == 1 then -- easy
         if traitEquipped ~= traitSaved or weaponTypeEquipped ~= weaponTypeSaved or setIdEquipped ~= setIdSaved then
@@ -94,6 +94,7 @@ function WWV.DidSetupSwapCorrectly( workAround )
                 local equippedUId  = Id64ToString( GetItemUniqueId( BAG_WORN, equipSlot ) )
                 local savedUId     = setupTable.gear[ equipSlot ].id
                 local success      = nil
+                logger:Debug( " equipSlot: %s, %s // %s", GetString( "SI_EQUIPSLOT", equipSlot ), equippedLink, savedLink )
                 if WWV.CompareItemLinks( equippedLink, savedLink, equippedUId, savedUId ) then
                     success = true
                 else


### PR DESCRIPTION
- Fixed set ID recognition in the setup compare function, so now it actually checks the correct variable and not how many pieces are equipped.
- Moved the initial validation function. Now it only checks the setup when equipping a setup instead of moving gear.