### PR TITLE
Update for Scribing

### DIFF
--- a/src/WizardsWardrobe.lua
+++ b/src/WizardsWardrobe.lua
@@ -245,15 +245,14 @@ end
 function WW.GetBaseAbilityId( abilityId )
 	if abilityId == 0 then return 0 end
 	local playerSkillProgressionData = SKILLS_DATA_MANAGER:GetProgressionDataByAbilityId( abilityId )
-	if not playerSkillProgressionData then
-		return nil
+    if not playerSkillProgressionData then
+        return nil
+    end
+	if playerSkillProgressionData:GetSkillData():IsCraftedAbility() then
+		return abilityId
 	end
-	local playerSkillProgressionSkillData = playerSkillProgressionData:GetSkillData()
-	if playerSkillProgressionSkillData and type(playerSkillProgressionSkillData.GetMorphData) == "function" then
-		local baseMorphData = playerSkillProgressionSkillData:GetMorphData(MORPH_SLOT_BASE)
-		abilityId = baseMorphData:GetAbilityId()
-	end
-	return abilityId
+	local baseMorphData = playerSkillProgressionData:GetSkillData():GetMorphData( MORPH_SLOT_BASE )
+	return baseMorphData:GetAbilityId()
 end
 
 function WW.LoadGear( setup )

--- a/src/WizardsWardrobe.lua
+++ b/src/WizardsWardrobe.lua
@@ -248,8 +248,12 @@ function WW.GetBaseAbilityId( abilityId )
 	if not playerSkillProgressionData then
 		return nil
 	end
-	local baseMorphData = playerSkillProgressionData:GetSkillData():GetMorphData( MORPH_SLOT_BASE )
-	return baseMorphData:GetAbilityId()
+	local playerSkillProgressionSkillData = playerSkillProgressionData:GetSkillData()
+	if playerSkillProgressionSkillData and type(playerSkillProgressionSkillData.GetMorphData) == "function" then
+		local baseMorphData = playerSkillProgressionSkillData:GetMorphData(MORPH_SLOT_BASE)
+		abilityId = baseMorphData:GetAbilityId()
+	end
+	return abilityId
 end
 
 function WW.LoadGear( setup )
@@ -479,7 +483,7 @@ end
 function WW.SaveCP( setup )
 	local cpTable = {}
 	for slotIndex = 1, 12 do
-		cpTable[ slotIndex ] = GetSlotBoundId( slotIndex, HOTBAR_CATEGORY_CHAMPION )
+		cpTable[ slotIndex ] = WW.GetSlotBoundAbilityId( slotIndex, HOTBAR_CATEGORY_CHAMPION )
 	end
 	setup:SetCP( cpTable )
 end

--- a/src/WizardsWardrobeGui.lua
+++ b/src/WizardsWardrobeGui.lua
@@ -885,8 +885,10 @@ function WWG.AquireSetupControl( setup )
 					return
 				end
 
-				if progression:IsChainingAbility() then
-					abilityId = GetEffectiveAbilityIdForAbilityOnHotbar( abilityId, hotbarCategory )
+				if type(progression.IsChainingAbility) == "function" then
+					if progression:IsChainingAbility() then
+						abilityId = GetEffectiveAbilityIdForAbilityOnHotbar( abilityId, hotbarCategory )
+					end
 				end
 
 				ClearCursor()

--- a/src/WizardsWardrobeGui.lua
+++ b/src/WizardsWardrobeGui.lua
@@ -885,9 +885,9 @@ function WWG.AquireSetupControl( setup )
 					return
 				end
 
-				if type(progression.IsChainingAbility) == "function" then
+				if not progression:GetSkillData():IsCraftedAbility() then
 					if progression:IsChainingAbility() then
-						abilityId = GetEffectiveAbilityIdForAbilityOnHotbar( abilityId, hotbarCategory )
+						abilityId = GetEffectiveAbilityIdForAbilityOnHotbar(abilityId, hotbarCategory)
 					end
 				end
 

--- a/src/WizardsWardrobeUtils.lua
+++ b/src/WizardsWardrobeUtils.lua
@@ -25,10 +25,21 @@ function WW.ChangeItemLinkStyle( itemLink, linkStyle )
 	return string.format( "%s%d%s", itemLink:sub( 1, 2 ), linkStyle, itemLink:sub( 4 ) )
 end
 
+function WW.GetSlotBoundAbilityId(slotIndex, hotbarIndex)
+    local slottedId = GetSlotBoundId(slotIndex, hotbarIndex)
+    local actionType = GetSlotType(slotIndex, hotbarIndex)
+
+    if actionType == ACTION_TYPE_CRAFTED_ABILITY then
+        slottedId = GetAbilityIdForCraftedAbilityId(id)
+    end
+
+    return slottedId
+end
+
 function WW.CompareCP( setup )
 	for slotIndex = 1, 12 do
 		local savedSkillId = setup:GetCP()[ slotIndex ]
-		local selectedSkilId = GetSlotBoundId( slotIndex, HOTBAR_CATEGORY_CHAMPION )
+		local selectedSkilId = WW.GetSlotBoundAbilityId(slotIndex, HOTBAR_CATEGORY_CHAMPION)
 		if not savedSkillId or savedSkillId ~= selectedSkilId then
 			return false
 		end

--- a/src/modules/WizardsWardrobePrebuff.lua
+++ b/src/modules/WizardsWardrobePrebuff.lua
@@ -66,7 +66,7 @@ function WWP.OnPrebuffed(_, slotIndex)
 	if WWP.cache.spell.slot ~= slotIndex then return end
 	
 	-- skill already gone
-	if not WW.AreSkillsEqual(WWP.cache.spell.id, GetSlotBoundId(slotIndex, GetActiveHotbarCategory())) then
+	if not WW.AreSkillsEqual(WWP.cache.spell.id, WW.GetSlotBoundAbilityId(slotIndex, GetActiveHotbarCategory())) then
 		WWP.cache = {}
 		return
 	end
@@ -96,7 +96,7 @@ function WWP.GetCurrentHotbar()
 	local skillTable = {}
 	for slot = 3, 8 do
 		local hotbarCategory = GetActiveHotbarCategory()
-		local abilityId = GetSlotBoundId(slot, hotbarCategory)
+		local abilityId = WW.GetSlotBoundAbilityId(slot, hotbarCategory)
 		local baseId = WW.GetBaseAbilityId(abilityId)
 		skillTable[slot] = baseId
 	end


### PR DESCRIPTION
One odd bug that doesn't cause a UI error but should probably be looked at still: in the WizardsWardrobe saved builds window if you replace a scribed skill with a regular skill it doesn't play the sound. The sound plays the other direction though.

This fixes a bunch of other issues with changing skills in saved builds that scribing had caused though.