### PR TITLE
Validation fixes / setup swap improvements

### DIFF
--- a/src/WizardsWardrobe.txt
+++ b/src/WizardsWardrobe.txt
@@ -1,7 +1,7 @@
 ## Title: Wizard's Wardrobe
 ## Author: ownedbynico, |c268074JN_Slevin|r
-## Version: 1.18.0
-## AddOnVersion: 1180
+## Version: 1.18.1
+## AddOnVersion: 1181
 ## Description: Throw all your setups into the wardrobe and let the wizard equip them exactly when you need it.
 ## APIVersion: 101041 101042
 ## DependsOn: LibAddonMenu-2.0>=35 LibChatMessage>=105 LibDebugLogger>=105 LibAsync>=20304

--- a/src/WizardsWardrobeSetupValidation.lua
+++ b/src/WizardsWardrobeSetupValidation.lua
@@ -146,6 +146,10 @@ function WWV.DidSetupSwapCorrectly( workAround )
                         else
                             success = false
                         end
+                    elseif WW.settings.unequipEmpty and equippedLink == "" then
+                        success = true
+                    elseif not WW.settings.unequipEmpty then
+                        success = true
                     else
                         failedT[ # failedT + 1 ] = GetString( "SI_EQUIPSLOT", equipSlot )
                         logger:Verbose( "Equipped %s // saved %s", equippedLink, savedLink )
@@ -214,31 +218,37 @@ function WWV.DidSetupSwapCorrectly( workAround )
                         equippedSkill = slotData.abilityId
                     else
                         if slotData == ZO_EMPTY_SLOTTABLE_ACTION then
-                            --[[ logger:Debug( "slotData.abilityId =" .. tostring( slotData.abilityId ) )
-                            if WW.settings.unequipEmpty then
-                                skillSuccess = true
-                            else
-                                if savedBaseId == 0 then
-                                    skillSuccess = true
-                                else
-                                    failedT[ # failedT + 1 ] = GetAbilityName( savedSkill )
-                                    skillSuccess = false
-                                end
-                            end ]]
+
                         else
                             equippedSkill = slotData:GetEffectiveAbilityId()
                         end
                     end
                 end
-                if equippedSkill ~= 0 and equippedSkill ~= 195031 then
+                local areSkillsEqual = WW.AreSkillsEqual( equippedSkill, savedSkill )
+                if areSkillsEqual then
+                    skillSuccess = true
+                else
+                    if WW.settings.unequipEmpty then
+                        if equippedSkill == 0 then
+                            skillSuccess = true
+                        else
+                            failedT[ # failedT + 1 ] = GetAbilityName( savedSkill )
+                            skillSuccess = false
+                            logger:Warn( "Skills did not swap correctly: %s // %s (empty skill)",
+                                GetAbilityName( equippedSkill ),
+                                GetAbilityName( savedSkill ) )
+                        end
+                    end
+                end
+                --[[   if equippedSkill ~= 0 and equippedSkill ~= 195031 then
                     equippedBaseId = WW.GetBaseAbilityId( equippedSkill )
                 end
                 if savedSkill ~= 195031 then
-                    equippedBaseId = WW.GetBaseAbilityId( equippedSkill )
-                end
+                    savedBaseId = WW.GetBaseAbilityId( savedSkill )
+                end ]]
 
-                logger:Verbose( "SavedBaseId = %d, name= %s, equippedBaseId = %d, name = %s", savedBaseId,
-                    GetAbilityName( savedBaseId ), equippedBaseId,
+                logger:Verbose( "SavedBaseId = %s, name= %s, equippedBaseId = %s, name = %s", tostring( savedBaseId ),
+                    GetAbilityName( savedBaseId ), tostring( equippedBaseId ),
                     GetAbilityName( equippedBaseId ) )
                 --[[ logger:Debug( "SavedSkill = %s, equippedSkill = %s", GetAbilityName( savedSkill ),
                     GetAbilityName( equippedSkill ) ) ]]
@@ -291,6 +301,11 @@ function WWV.DidSetupSwapCorrectly( workAround )
         else
             logger:Warn( "Skills did not swap correctly" )
         end
+    end
+    if check then
+        logger:Debug( "Gear swapped correctly" )
+    else
+        logger:Warn( "Gear did not swap correctly" )
     end
     if not isGearPresent then check = true end
     if not skillSuccess then check = false end

--- a/src/WizardsWardrobeUtils.lua
+++ b/src/WizardsWardrobeUtils.lua
@@ -30,7 +30,7 @@ function WW.GetSlotBoundAbilityId( slotIndex, hotbarIndex )
 	local actionType = GetSlotType( slotIndex, hotbarIndex )
 
 	if actionType == ACTION_TYPE_CRAFTED_ABILITY then
-		slottedId = GetAbilityIdForCraftedAbilityId( id )
+		slottedId = GetAbilityIdForCraftedAbilityId( slottedId )
 	end
 
 	return slottedId

--- a/src/modules/WizardsWardrobePrebuff.lua
+++ b/src/modules/WizardsWardrobePrebuff.lua
@@ -261,7 +261,7 @@ function WWP.CreatePrebuffWindow()
 				end
 
 				if progression:IsChainingAbility() then
-					abilityId = GetEffectiveAbilityIdForAbilityOnHotbar( abilityId, hotbar )
+					abilityId = GetEffectiveAbilityIdForAbilityOnHotbar( abilityId, GetActiveHotbarCategory() )
 				end
 
 				ClearCursor()


### PR DESCRIPTION
03.05.24 v1.18.1 by JN Slevin
- fixed yet another issue with empty slots (this is the same issue where it told you your skills did not swap correctly even though they did) don't ask me how this happened but it should be fixed now
- fixed yet another issue where if you had the unequip empty option set to on it would not unequip every piece, which would cause the setup validation to fail
- code maintenance in the validation file
- fix for a potential issue within the scribing functionality (thanks DakJaniels)