### PR TITLE
fix for error in update 45

### DIFF
--- a/src/WizardsWardrobeConst.lua
+++ b/src/WizardsWardrobeConst.lua
@@ -197,7 +197,7 @@ WW.CONDITIONS = {
 WW.DISABLEDBAGS = {
 	[ BAG_GUILDBANK ] = true,
 	[ BAG_BUYBACK ] = true,
-	[ BAG_DELETE ] = true,
+	-- [ BAG_DELETE ] = true,
 	[ BAG_VIRTUAL ] = true,
 }
 


### PR DESCRIPTION
In update 45, wizzard's wardrobe throws an error and it's not possible to open the addon gui.
For a quick fix, the value BAG_DELETE has to be disabled or removed from constants.
As I see this as a quick fix, i just disabled the BAG_DELETE by commenting it out.

