### PR TITLE
p45 unslottable Champion Point Fix

### DIFF
--- a/src/WizardsWardrobe.lua
+++ b/src/WizardsWardrobe.lua
@@ -723,7 +723,7 @@ function WW.LoadCP( setup )
 		PrepareChampionPurchaseRequest()
 		cpTask:For( 1, MAX_CHAMPION_SLOTTABLES ):Do( function( slotIndex )
 			local starId = setup:GetCP()[ slotIndex ]
-			if starId and starId > 0 then
+			if starId and starId > 0 and CanChampionSkillTypeBeSlotted(GetChampionSkillType(starId)) then
 				local skillPoints = GetNumPointsSpentOnChampionSkill( starId )
 				if skillPoints > 0 then
 					AddHotbarSlotToChampionPurchaseRequest( slotIndex, starId )


### PR DESCRIPTION
Many legacy builds which included green Champion Points which are now unslottable due to P45 cause UI errors and make wizards fail to equip slotted CP. This fix allows Wizards Wardrobe to do a noop when attempting to slot a champion point to the hotbar when the skill is not a slottable skill per the ESO API.

This has impacted many older raiders (including myself) who may have several hundred builds with random green champion points and don't have the patience or time to manually fix each setup and wait for the 30s champion point cooldown per-build to sanitize the green slottables.