### PR TITLE
refactor(active-champion-point-skills): resolve duplicated fix …

### DIFF
--- a/src/WizardsWardrobe.lua
+++ b/src/WizardsWardrobe.lua
@@ -725,19 +725,17 @@ function WW.LoadCP( setup )
 		PrepareChampionPurchaseRequest()
 		cpTask:For( 1, MAX_CHAMPION_SLOTTABLES ):Do( function( slotIndex )
 			local starId = setup:GetCP()[ slotIndex ]
-			if starId and starId > 0 and CanChampionSkillTypeBeSlotted(GetChampionSkillType(starId)) then
-				local skillPoints = GetNumPointsSpentOnChampionSkill( starId )
-				if skillPoints > 0 then
-					-- fixes to ignore non slotable CP (Will be empty) by BloodStainChild666
-					if CHAMPION_SKILL_TYPE_NORMAL ~= GetChampionSkillType(starId) then					
-						AddHotbarSlotToChampionPurchaseRequest( slotIndex, starId )
+			if starId and starId > 0 then
+				if CanChampionSkillTypeBeSlotted(GetChampionSkillType(starId)) then
+					local skillPoints = GetNumPointsSpentOnChampionSkill( starId )
+					if skillPoints > 0 then									
+							AddHotbarSlotToChampionPurchaseRequest( slotIndex, starId )
 					else
-						AddHotbarSlotToChampionPurchaseRequest( slotIndex, 0 )
-						WW.Log( "CP can't be sloted, ignored. [%s]", WW.LOGTYPES.INFO, WW.CPCOLOR[ slotIndex ],
+						WW.Log( GetString( WW_MSG_CPENOENT ), WW.LOGTYPES.ERROR, WW.CPCOLOR[ slotIndex ],
 							zo_strformat( "<<C:1>>", GetChampionSkillName( starId ) ) )
 					end
 				else
-					WW.Log( GetString( WW_MSG_CPENOENT ), WW.LOGTYPES.ERROR, WW.CPCOLOR[ slotIndex ],
+					WW.Log( GetString( WW_MSG_CPNOTSLOTTABLEINFO ), WW.LOGTYPES.INFO, WW.CPCOLOR[ slotIndex ],
 						zo_strformat( "<<C:1>>", GetChampionSkillName( starId ) ) )
 				end
 			else

--- a/src/lang/de.lua
+++ b/src/lang/de.lua
@@ -26,6 +26,7 @@ local language = {
 	WW_MSG_LOADCP = "Lade CP [%s] aus [%s].",
 	WW_MSG_SAVECP = "Speichere CP in Setup %s.",
 	WW_MSG_CPENOENT = "Stern [%s] ist nicht freigeschaltet.",
+	WW_MSG_CPNOTSLOTTABLEINFO = "Stern [%s] kann nicht geslottet werden, wird ignoriert.",
 	WW_MSG_CPCOOLDOWN = "Champion Punkte werden in %ss gewechselt.",
 	WW_MSG_CPCOOLDOWNOVER = "Champion Punkte gewechselt.",
 	WW_MSG_TELEPORT_PLAYER = "Teleportiere zu %s.",

--- a/src/lang/en.lua
+++ b/src/lang/en.lua
@@ -25,6 +25,7 @@ local language = {
 	WW_MSG_LOADCP = "Loading CP %s from [%s].",
 	WW_MSG_SAVECP = "Saving CP to setup %s.",
 	WW_MSG_CPENOENT = "Could not slot [%s]. Star is not unlocked.",
+	WW_MSG_CPNOTSLOTTABLEINFO = "Could not slot [%s]. Star is not slottable.",
 	WW_MSG_CPCOOLDOWN = "Champion points will be changed in %ss.",
 	WW_MSG_CPCOOLDOWNOVER = "Champion points changed.",
 	WW_MSG_TELEPORT_PLAYER = "Teleporting to %s.",

--- a/src/lang/es.lua
+++ b/src/lang/es.lua
@@ -26,6 +26,7 @@ local language = {
     WW_MSG_LOADCP = "Cargando CP %s desde [%s].",
     WW_MSG_SAVECP = "Guardando CP en la configuración %s.",
     WW_MSG_CPENOENT = "No se pudo equipar [%s]. La estrella no está desbloqueada.",
+	WW_MSG_CPNOTSLOTTABLEINFO = "No se pudo equipar [%s]. La estrella no es equipable.",
     WW_MSG_CPCOOLDOWN = "Los puntos de campeón se cambiarán en %ss.",
     WW_MSG_CPCOOLDOWNOVER = "Puntos de campeón cambiados.",
     WW_MSG_TELEPORT_PLAYER = "Teletransportándote a %s.",

--- a/src/lang/fr.lua
+++ b/src/lang/fr.lua
@@ -26,6 +26,7 @@ local language = {
 	WW_MSG_LOADCP = "Chargement CP %s de [%s].",
 	WW_MSG_SAVECP = "Sauvegarde CP to profil %s.",
 	WW_MSG_CPENOENT = "Impossible à équiper [%s]. CP non débloqué.",
+	WW_MSG_CPNOTSLOTTABLEINFO = "Impossible à équiper [%s]. CP non équipable.",
 	WW_MSG_CPCOOLDOWN = "Les points champion seront changés dans %s s.",
 	WW_MSG_CPCOOLDOWNOVER = "Points champion changés.",
 	WW_MSG_TELEPORT_PLAYER = "Téléportation vers %s.",

--- a/src/lang/ru.lua
+++ b/src/lang/ru.lua
@@ -25,6 +25,7 @@ local language = {
 	WW_MSG_LOADCP = "Загрузка CP %s из [%s].",
 	WW_MSG_SAVECP = "Сохранение CP для набора %s.",
 	WW_MSG_CPENOENT = "Не удалось поставить [%s] потому что созвездие не разблокировано.",
+	WW_MSG_CPNOTSLOTTABLEINFO = "Could not slot [%s]. Star is not slottable.", -- Need help in translation
 	WW_MSG_CPCOOLDOWN = "Созвездия будут изменены через %ss.",
 	WW_MSG_CPCOOLDOWNOVER = "Созвездия изменены.",
 	WW_MSG_TOGGLEAUTOEQUIP = "Автопереключение %s.",

--- a/src/lang/zh.lua
+++ b/src/lang/zh.lua
@@ -26,6 +26,7 @@ local language = {
     WW_MSG_LOADCP = "装载CP %s , 位于 [%s]  配装页.",
     WW_MSG_SAVECP = "存储CP至配装 %s.",
     WW_MSG_CPENOENT = "无法装载 [%s]. CP未解锁.",
+	WW_MSG_CPNOTSLOTTABLEINFO = "Could not slot [%s]. Star is not slottable.", -- Need help in translation
     WW_MSG_CPCOOLDOWN = "将在 %s 秒后应用CP变更.",
     WW_MSG_CPCOOLDOWNOVER = "CP点变更.",
     WW_MSG_TELEPORT_PLAYER = "传送至 %s.",


### PR DESCRIPTION
…for active cp skills getting passives (update 45 fallen banners)

To keep up the performance, unnecessary calculations should be reduced and a fail-early policy should be followed. That's why `if CanChampionSkillTypeBeSlotted()` gets used in line 729. We don't need to check if a star is unlocked when it's not even slottable in the first place :D

Also: Translation files should be used (where is the default for translation).