### PR TITLE
feature: cycle pages via button

### DIFF
--- a/src/Bindings.xml
+++ b/src/Bindings.xml
@@ -16,6 +16,12 @@
 			<Action name="WW_HOTKEY_SETUP_NEXT">
 				<Down>WizardsWardrobe.LoadSetupAdjacent(1)</Down>
 			</Action>
+			<Action name="WW_HOTKEY_PAGE_RIGHT">
+				<Down>WizardsWardrobe.NextPage(true)</Down>
+			</Action>
+			<Action name="WW_HOTKEY_PAGE_LEFT">
+				<Down>WizardsWardrobe.NextPage(false)</Down>
+			</Action>
 			<Action name="WW_HOTKEY_UNDRESS">
 				<Down>WizardsWardrobe.Undress()</Down>
 			</Action>

--- a/src/WizardsWardrobe.lua
+++ b/src/WizardsWardrobe.lua
@@ -52,8 +52,6 @@ function WW.NextPage( directRight )
 	local pageName = WW.pages[ WW.selection.zone.tag ][ WW.selection.pageId ].name
 	local msg = GetString( WW_MSG_PAGE_LOADED )
 	WW.Log( msg, WW.LOGTYPES.NORMAL, 'FFFFFF', pageName, WW.selection.zone.name )
-	
-	WW.LoadSetupCurrent( 1, false ) -- load first setup of the newly selected page
 end
 
 function WW.IsReadyToSwap()

--- a/src/WizardsWardrobe.lua
+++ b/src/WizardsWardrobe.lua
@@ -2,6 +2,7 @@ WizardsWardrobe = WizardsWardrobe or {}
 local WW = WizardsWardrobe
 local WWQ = WW.queue
 local WWV = WW.validation
+local WWG = WW.gui
 
 WW.name = "WizardsWardrobe"
 WW.simpleName = "Wizard's Wardrobe"
@@ -39,6 +40,22 @@ function WW.LoadSetupAdjacent( direct, skipValidation )
 	WW.LoadSetup( zone, pageId, newSetupId, false, skipValidation )
 end
 
+function WW.NextPage( directRight )
+	local currentPage = WW.selection.pageId
+	if directRight and currentPage < #WW.pages[ WW.selection.zone.tag ] then WW.selection.pageId = currentPage + 1 end -- going right and have space
+	if directRight and currentPage >= #WW.pages[ WW.selection.zone.tag ] then WW.selection.pageId = 1 end -- at last page -> cycle to first
+	if not directRight and currentPage == 1 then WW.selection.pageId = #WW.pages[ WW.selection.zone.tag ] end -- if cycling left and on first, cycle to last
+	if not directRight and currentPage > 1 then WW.selection.pageId = currentPage - 1 end -- going left from another page
+
+	WWG.BuildPage( WW.selection.zone, WW.selection.pageId, true ) -- make sure the ui is at current page
+
+	local pageName = WW.pages[ WW.selection.zone.tag ][ WW.selection.pageId ].name
+	local msg = GetString( WW_MSG_PAGE_LOADED )
+	WW.Log( msg, WW.LOGTYPES.NORMAL, 'FFFFFF', pageName, WW.selection.zone.name )
+	
+	WW.LoadSetupCurrent( 1, false ) -- load first setup of the newly selected page
+end
+
 function WW.IsReadyToSwap()
 	return not IsUnitInCombat( "player" ) and not IsUnitDeadOrReincarnating( "player" )
 end
@@ -73,7 +90,7 @@ function WW.LoadSetup( zone, pageId, index, auto, skipValidation )
 		local logMessage = WW.IsReadyToSwap() and GetString( WW_MSG_LOADSETUP ) or GetString( WW_MSG_LOADINFIGHT )
 		local logColor = WW.IsReadyToSwap() and WW.LOGTYPES.NORMAL or WW.LOGTYPES.INFO
 
-		WW.Log( logMessage, logColor, "FFFFFF", setup:GetName(), zone.name )
+		WW.Log( logMessage, logColor, "FFFFFF", setup:GetName(), pageName )
 
 		setupTask:WaitUntil( function()
 			return WW.IsReadyToSwap()

--- a/src/lang/de.lua
+++ b/src/lang/de.lua
@@ -4,6 +4,7 @@ local language = {
 	WW_MSG_FIRSTSTART =
 	"Wenn du zum ersten Mal Wizard's Wardrobe benutzt, sieh dir bitte das FAQ und die Liste der Funktionen auf %s an. Dort werden die meisten Fragen schon beantwortet.",
 	WW_MSG_ENOENT = "Ein solcher Eintrag existiert nicht.",
+	WW_MSG_PAGE_LOADED = "Seite [%s] aus [%s] wurde geladen.",
 	WW_MSG_ERROR = "FEHLER!",
 	WW_MSG_LOADSETUP = "Lade Setup [%s] aus [%s].",
 	WW_MSG_LOADINFIGHT = "Lade Setup [%s] aus [%s] nach dem Kampf.",
@@ -303,6 +304,8 @@ local language = {
 	-- KEYBINDS
 	SI_BINDING_NAME_WW_HOTKEY_SHOW_UI = "Wizard's Wardrobe öffnen",
 	SI_BINDING_NAME_WW_HOTKEY_FIXES_FLIP_SHOULDERS = "Schulter reparieren",
+	SI_BINDING_NAME_WW_HOTKEY_PAGE_RIGHT = "Nächste Seite",
+	SI_BINDING_NAME_WW_HOTKEY_PAGE_LEFT = "Vorherige Seite",
 	SI_BINDING_NAME_WW_HOTKEY_SETUP_1 = "Setup 1 (Trash)",
 	SI_BINDING_NAME_WW_HOTKEY_SETUP_2 = "Setup 2",
 	SI_BINDING_NAME_WW_HOTKEY_SETUP_3 = "Setup 3",

--- a/src/lang/en.lua
+++ b/src/lang/en.lua
@@ -4,6 +4,7 @@ local language = {
 	WW_MSG_FIRSTSTART =
 	"If you are using Wizard's Wardrobe for the first time please be sure to check out the FAQ and feature list on the %s page. Most questions are already answered there.",
 	WW_MSG_ENOENT = "There is no such entry.",
+	WW_MSG_PAGE_LOADED = "Page [%s] from [%s] has been loaded.",
 	WW_MSG_ERROR = "ERROR!",
 	WW_MSG_LOADSETUP = "Loading setup [%s] from [%s].",
 	WW_MSG_LOADINFIGHT = "Loading setup [%s] from [%s] after combat.",
@@ -334,6 +335,8 @@ local language = {
 	-- KEYBINDS
 	SI_BINDING_NAME_WW_HOTKEY_SHOW_UI = "Open Wizard's Wardrobe",
 	SI_BINDING_NAME_WW_HOTKEY_FIXES_FLIP_SHOULDERS = "Fix Shoulder",
+	SI_BINDING_NAME_WW_HOTKEY_PAGE_RIGHT = "Next Page",
+	SI_BINDING_NAME_WW_HOTKEY_PAGE_LEFT = "Previous Page",
 	SI_BINDING_NAME_WW_HOTKEY_SETUP_1 = "Setup 1 (Trash)",
 	SI_BINDING_NAME_WW_HOTKEY_SETUP_2 = "Setup 2",
 	SI_BINDING_NAME_WW_HOTKEY_SETUP_3 = "Setup 3",


### PR DESCRIPTION
Added hotkey settings + logic to cycle through pages
If a page is cycled via hotkey, the gui auto rebuilds with the newly selected page, so that when opening the gui it is synced with the current page in use by the user

Updated the log to show from which page the setup was loaded instead of from which zone -- I'm not perfectly sure on how to handle this best... looking for feedback.

I propose that switching the page logs to the user a message 
>"Page A has been loaded from zone B"

And then that loading a setup logs 
> "Setup C has been loaded from page A"

-> a bit a more page centric logging since this will be doable via hotkeys whereas zones are not (? yet?)

Feel free to give feedback